### PR TITLE
Clean stray text markers from CombinedBets

### DIFF
--- a/components/CombinedBets.jsx
+++ b/components/CombinedBets.jsx
@@ -100,7 +100,7 @@ function mapHTFT(code) {
   const m = String(code || "").trim().toUpperCase();
   const to = (c) => (c === "1" ? "Home" : c === "2" ? "Away" : c === "X" ? "Draw" : c);
   const [a, b] = m.split("/");
-  もう  if (!a || !b) return null;
+  if (!a || !b) return null;
   return `${to(a)}–${to(b)}`;
 }
 function normalizeSelection(it, marketHint) {


### PR DESCRIPTION
## Summary
- remove stray copy/paste text so the HT-FT helper returns early correctly

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab59f27248322aa0459c2f154a1a0