### PR TITLE
Parse and consume expanded team stats in value-bets meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,26 @@ double-processing slots while still tolerating delayed cron invocations. The
 default window is **75 minutes**. Operations can adjust it without editing the
 workflow by defining the repository variable `SNAPSHOT_GUARD_MINUTES`
 (`Settings → Secrets and variables → Actions`).
+
+## Value bets meta stats schema
+
+`/api/cron/enrich` now persists a compact stats payload for each team under
+`meta.stats.home` and `meta.stats.away`. All numeric fields are JSON numbers so
+they remain serializable and easy to consume in follow-up jobs.
+
+Each team block is optional and uses the following keys when data is available:
+
+- `form`: recent sequence (latest 6 chars from API form string, only `W/D/L`).
+- `played`: object with `{ h, a, t }` counts (home, away, total).
+- `gf_avg` / `ga_avg`: average goals scored / conceded per match `{ h, a, t }`.
+- `gf_tot` / `ga_tot`: total goals scored / conceded in the season `{ h, a, t }`.
+- `win_pct`, `lose_pct`, `draw_pct`: percentage (0–100) splits by result `{ h, a, t }`.
+- `btts_pct`: both teams to score percentage `{ h, a, t }`.
+- `over25_pct` / `under25_pct`: over/under 2.5 goal percentages `{ h, a, t }`.
+- `clean_pct`: clean sheet percentage `{ h, a, t }`.
+- `fail_pct`: failed-to-score percentage `{ h, a, t }`.
+- `xg`: expected goals summary, `{ f, a }` for scored and conceded (if provided).
+
+Consumers should treat every key as optional and default to the aggregate (`t`)
+when a side-specific sample (`h`/`a`) is missing or based on a very small
+number of matches.

--- a/pages/api/value-bets-chooser.js
+++ b/pages/api/value-bets-chooser.js
@@ -37,6 +37,101 @@ function ymdBelgrade(d = new Date()) {
 }
 const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
 
+const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
+
+function safeAverage(values) {
+  if (!Array.isArray(values)) return null;
+  const arr = values.filter(isFiniteNumber);
+  if (!arr.length) return null;
+  return arr.reduce((sum, v) => sum + v, 0) / arr.length;
+}
+
+function sumTwo(a, b) {
+  const arr = [];
+  if (isFiniteNumber(a)) arr.push(a);
+  if (isFiniteNumber(b)) arr.push(b);
+  if (!arr.length) return null;
+  return arr.reduce((sum, v) => sum + v, 0);
+}
+
+function normalizeStats(metaStats) {
+  if (!metaStats || typeof metaStats !== "object") {
+    return { home: null, away: null };
+  }
+  const home = metaStats.home && typeof metaStats.home === "object" ? metaStats.home : null;
+  const away = metaStats.away && typeof metaStats.away === "object" ? metaStats.away : null;
+  return { home, away };
+}
+
+function getTeamValue(team, field, side, minSample = 5) {
+  if (!team || typeof team !== "object") return null;
+  const triple = team[field];
+  if (!triple || typeof triple !== "object") return null;
+
+  if (side === "home") {
+    const sample = team?.played?.h;
+    if (isFiniteNumber(sample) && sample >= minSample && isFiniteNumber(triple.h)) return triple.h;
+  }
+  if (side === "away") {
+    const sample = team?.played?.a;
+    if (isFiniteNumber(sample) && sample >= minSample && isFiniteNumber(triple.a)) return triple.a;
+  }
+
+  if (isFiniteNumber(triple.t)) return triple.t;
+
+  const vals = [];
+  if (isFiniteNumber(triple.h)) vals.push(triple.h);
+  if (isFiniteNumber(triple.a)) vals.push(triple.a);
+  return vals.length ? safeAverage(vals) : null;
+}
+
+function expectedGoalsFromStats(home, away) {
+  const combos = [];
+
+  const attackHome = sumTwo(
+    getTeamValue(home, "gf_avg", "home"),
+    getTeamValue(away, "ga_avg", "away")
+  );
+  if (isFiniteNumber(attackHome)) combos.push(attackHome);
+
+  const attackAway = sumTwo(
+    getTeamValue(away, "gf_avg", "away"),
+    getTeamValue(home, "ga_avg", "home")
+  );
+  if (isFiniteNumber(attackAway)) combos.push(attackAway);
+
+  const xgHome = sumTwo(
+    isFiniteNumber(home?.xg?.f) ? home.xg.f : null,
+    isFiniteNumber(away?.xg?.a) ? away.xg.a : null
+  );
+  if (isFiniteNumber(xgHome)) combos.push(xgHome);
+
+  const xgAway = sumTwo(
+    isFiniteNumber(away?.xg?.f) ? away.xg.f : null,
+    isFiniteNumber(home?.xg?.a) ? home.xg.a : null
+  );
+  if (isFiniteNumber(xgAway)) combos.push(xgAway);
+
+  if (!combos.length) return null;
+  return safeAverage(combos);
+}
+
+function formScore(team) {
+  if (!team || typeof team.form !== "string") return null;
+  const cleaned = team.form.replace(/[^WDL]/gi, "").slice(-6);
+  if (!cleaned) return null;
+  let pts = 0;
+  let matches = 0;
+  for (const ch of cleaned) {
+    const c = ch.toUpperCase();
+    if (c === "W") pts += 3;
+    else if (c === "D") pts += 1;
+    matches += 1;
+  }
+  if (!matches) return null;
+  return pts / matches;
+}
+
 // ista mikro-korekcija kao u value-bets-meta (injuries + H2H%)
 // ograničeno na ±3 p.p., konzervativno
 function computeAdjPP(item, meta) {
@@ -57,6 +152,142 @@ function computeAdjPP(item, meta) {
   } else if (injTotal >= 2) {
     if (market === "OU2.5" && pick === "O2.5") adj -= 1;
     if (market === "BTTS" && (pick === "Y" || pick === "YES")) adj -= 1;
+  }
+
+  const { home: statsHome, away: statsAway } = normalizeStats(meta?.stats);
+  if (statsHome || statsAway) {
+    if (market === "OU2.5") {
+      let statsAdj = 0;
+      const overPctStat = safeAverage([
+        getTeamValue(statsHome, "over25_pct", "home"),
+        getTeamValue(statsAway, "over25_pct", "away"),
+      ]);
+      const underPctStat = safeAverage([
+        getTeamValue(statsHome, "under25_pct", "home"),
+        getTeamValue(statsAway, "under25_pct", "away"),
+      ]);
+      const expGoals = expectedGoalsFromStats(statsHome, statsAway);
+
+      if (pick === "O2.5") {
+        if (overPctStat !== null) {
+          if (overPctStat >= 68) statsAdj += 2;
+          else if (overPctStat >= 60) statsAdj += 1;
+          if (overPctStat <= 35) statsAdj -= 2;
+          else if (overPctStat <= 42) statsAdj -= 1;
+        } else if (underPctStat !== null) {
+          if (underPctStat >= 65) statsAdj -= 2;
+          else if (underPctStat >= 55) statsAdj -= 1;
+          if (underPctStat <= 35) statsAdj += 1;
+        }
+        if (expGoals !== null) {
+          if (expGoals >= 3.4) statsAdj += 1;
+          else if (expGoals <= 2.1) statsAdj -= 1;
+        }
+      } else if (pick === "U2.5") {
+        if (underPctStat !== null) {
+          if (underPctStat >= 65) statsAdj += 2;
+          else if (underPctStat >= 55) statsAdj += 1;
+          if (underPctStat <= 35) statsAdj -= 2;
+          else if (underPctStat <= 45) statsAdj -= 1;
+        } else if (overPctStat !== null) {
+          if (overPctStat >= 68) statsAdj -= 2;
+          else if (overPctStat >= 60) statsAdj -= 1;
+          if (overPctStat <= 35) statsAdj += 1;
+        }
+        if (expGoals !== null) {
+          if (expGoals <= 2.1) statsAdj += 1;
+          else if (expGoals >= 3.4) statsAdj -= 1;
+        }
+      }
+
+      adj += clamp(statsAdj, -2, 2);
+    }
+
+    if (market === "BTTS") {
+      const yes = pick === "Y" || pick === "YES";
+      let statsAdj = 0;
+      const bttsPctStat = safeAverage([
+        getTeamValue(statsHome, "btts_pct", "home"),
+        getTeamValue(statsAway, "btts_pct", "away"),
+      ]);
+      const failPctStat = safeAverage([
+        getTeamValue(statsHome, "fail_pct", "home"),
+        getTeamValue(statsAway, "fail_pct", "away"),
+      ]);
+      const cleanPctStat = safeAverage([
+        getTeamValue(statsHome, "clean_pct", "home"),
+        getTeamValue(statsAway, "clean_pct", "away"),
+      ]);
+
+      if (yes) {
+        if (bttsPctStat !== null) {
+          if (bttsPctStat >= 68) statsAdj += 2;
+          else if (bttsPctStat >= 60) statsAdj += 1;
+          if (bttsPctStat <= 32) statsAdj -= 2;
+          else if (bttsPctStat <= 40) statsAdj -= 1;
+        }
+        if (failPctStat !== null && failPctStat >= 45) statsAdj -= 1;
+        if (cleanPctStat !== null && cleanPctStat >= 45) statsAdj -= 1;
+      } else {
+        if (bttsPctStat !== null) {
+          if (bttsPctStat <= 32) statsAdj += 2;
+          else if (bttsPctStat <= 40) statsAdj += 1;
+          if (bttsPctStat >= 68) statsAdj -= 2;
+          else if (bttsPctStat >= 60) statsAdj -= 1;
+        }
+        if (failPctStat !== null && failPctStat >= 45) statsAdj += 1;
+        if (cleanPctStat !== null && cleanPctStat >= 45) statsAdj += 1;
+      }
+
+      adj += clamp(statsAdj, -2, 2);
+    }
+
+    if (market === "1X2") {
+      let statsAdj = 0;
+      const formHome = formScore(statsHome);
+      const formAway = formScore(statsAway);
+
+      if (pick === "1") {
+        const winPct = getTeamValue(statsHome, "win_pct", "home");
+        const losePct = getTeamValue(statsAway, "lose_pct", "away");
+        const support = safeAverage([winPct, losePct]);
+        if (support !== null) {
+          if (support >= 68) statsAdj += 1;
+          if (support >= 76) statsAdj += 1;
+          if (support <= 42) statsAdj -= 1;
+        }
+        if (formHome !== null && formAway !== null) {
+          const diff = formHome - formAway;
+          if (diff >= 1.0) statsAdj += 1;
+          else if (diff <= -1.0) statsAdj -= 1;
+        }
+      } else if (pick === "2") {
+        const winPct = getTeamValue(statsAway, "win_pct", "away");
+        const losePct = getTeamValue(statsHome, "lose_pct", "home");
+        const support = safeAverage([winPct, losePct]);
+        if (support !== null) {
+          if (support >= 68) statsAdj += 1;
+          if (support >= 76) statsAdj += 1;
+          if (support <= 42) statsAdj -= 1;
+        }
+        if (formHome !== null && formAway !== null) {
+          const diff = formAway - formHome;
+          if (diff >= 1.0) statsAdj += 1;
+          else if (diff <= -1.0) statsAdj -= 1;
+        }
+      } else if (pick === "X") {
+        const drawPctHome = getTeamValue(statsHome, "draw_pct", "home");
+        const drawPctAway = getTeamValue(statsAway, "draw_pct", "away");
+        const drawSupport = safeAverage([drawPctHome, drawPctAway]);
+        if (drawSupport !== null) {
+          if (drawSupport >= 36) statsAdj += 1;
+          if (drawSupport >= 42) statsAdj += 1;
+          if (drawSupport <= 24) statsAdj -= 1;
+        }
+      }
+
+      adj += clamp(statsAdj, -2, 2);
+    }
   }
 
   const h2hCnt = Number(meta?.h2h?.count || 0);

--- a/pages/api/value-bets-meta.js
+++ b/pages/api/value-bets-meta.js
@@ -35,6 +35,101 @@ function ymdBelgrade(d = new Date()) {
 }
 const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
 
+const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
+
+function safeAverage(values) {
+  if (!Array.isArray(values)) return null;
+  const arr = values.filter(isFiniteNumber);
+  if (!arr.length) return null;
+  return arr.reduce((sum, v) => sum + v, 0) / arr.length;
+}
+
+function sumTwo(a, b) {
+  const arr = [];
+  if (isFiniteNumber(a)) arr.push(a);
+  if (isFiniteNumber(b)) arr.push(b);
+  if (!arr.length) return null;
+  return arr.reduce((sum, v) => sum + v, 0);
+}
+
+function normalizeStats(metaStats) {
+  if (!metaStats || typeof metaStats !== "object") {
+    return { home: null, away: null };
+  }
+  const home = metaStats.home && typeof metaStats.home === "object" ? metaStats.home : null;
+  const away = metaStats.away && typeof metaStats.away === "object" ? metaStats.away : null;
+  return { home, away };
+}
+
+function getTeamValue(team, field, side, minSample = 5) {
+  if (!team || typeof team !== "object") return null;
+  const triple = team[field];
+  if (!triple || typeof triple !== "object") return null;
+
+  if (side === "home") {
+    const sample = team?.played?.h;
+    if (isFiniteNumber(sample) && sample >= minSample && isFiniteNumber(triple.h)) return triple.h;
+  }
+  if (side === "away") {
+    const sample = team?.played?.a;
+    if (isFiniteNumber(sample) && sample >= minSample && isFiniteNumber(triple.a)) return triple.a;
+  }
+
+  if (isFiniteNumber(triple.t)) return triple.t;
+
+  const vals = [];
+  if (isFiniteNumber(triple.h)) vals.push(triple.h);
+  if (isFiniteNumber(triple.a)) vals.push(triple.a);
+  return vals.length ? safeAverage(vals) : null;
+}
+
+function expectedGoalsFromStats(home, away) {
+  const combos = [];
+
+  const attackHome = sumTwo(
+    getTeamValue(home, "gf_avg", "home"),
+    getTeamValue(away, "ga_avg", "away")
+  );
+  if (isFiniteNumber(attackHome)) combos.push(attackHome);
+
+  const attackAway = sumTwo(
+    getTeamValue(away, "gf_avg", "away"),
+    getTeamValue(home, "ga_avg", "home")
+  );
+  if (isFiniteNumber(attackAway)) combos.push(attackAway);
+
+  const xgHome = sumTwo(
+    isFiniteNumber(home?.xg?.f) ? home.xg.f : null,
+    isFiniteNumber(away?.xg?.a) ? away.xg.a : null
+  );
+  if (isFiniteNumber(xgHome)) combos.push(xgHome);
+
+  const xgAway = sumTwo(
+    isFiniteNumber(away?.xg?.f) ? away.xg.f : null,
+    isFiniteNumber(home?.xg?.a) ? home.xg.a : null
+  );
+  if (isFiniteNumber(xgAway)) combos.push(xgAway);
+
+  if (!combos.length) return null;
+  return safeAverage(combos);
+}
+
+function formScore(team) {
+  if (!team || typeof team.form !== "string") return null;
+  const cleaned = team.form.replace(/[^WDL]/gi, "").slice(-6);
+  if (!cleaned) return null;
+  let pts = 0;
+  let matches = 0;
+  for (const ch of cleaned) {
+    const c = ch.toUpperCase();
+    if (c === "W") pts += 3;
+    else if (c === "D") pts += 1;
+    matches += 1;
+  }
+  if (!matches) return null;
+  return pts / matches;
+}
+
 function computeAdjPP(item, meta) {
   if (!meta || typeof item?.confidence_pct !== "number") return 0;
 
@@ -54,6 +149,142 @@ function computeAdjPP(item, meta) {
   } else if (injTotal >= 2) {
     if (market === "OU2.5" && pick === "O2.5") adj -= 1;
     if (market === "BTTS" && (pick === "Y" || pick === "YES")) adj -= 1;
+  }
+
+  const { home: statsHome, away: statsAway } = normalizeStats(meta?.stats);
+  if (statsHome || statsAway) {
+    if (market === "OU2.5") {
+      let statsAdj = 0;
+      const overPctStat = safeAverage([
+        getTeamValue(statsHome, "over25_pct", "home"),
+        getTeamValue(statsAway, "over25_pct", "away"),
+      ]);
+      const underPctStat = safeAverage([
+        getTeamValue(statsHome, "under25_pct", "home"),
+        getTeamValue(statsAway, "under25_pct", "away"),
+      ]);
+      const expGoals = expectedGoalsFromStats(statsHome, statsAway);
+
+      if (pick === "O2.5") {
+        if (overPctStat !== null) {
+          if (overPctStat >= 68) statsAdj += 2;
+          else if (overPctStat >= 60) statsAdj += 1;
+          if (overPctStat <= 35) statsAdj -= 2;
+          else if (overPctStat <= 42) statsAdj -= 1;
+        } else if (underPctStat !== null) {
+          if (underPctStat >= 65) statsAdj -= 2;
+          else if (underPctStat >= 55) statsAdj -= 1;
+          if (underPctStat <= 35) statsAdj += 1;
+        }
+        if (expGoals !== null) {
+          if (expGoals >= 3.4) statsAdj += 1;
+          else if (expGoals <= 2.1) statsAdj -= 1;
+        }
+      } else if (pick === "U2.5") {
+        if (underPctStat !== null) {
+          if (underPctStat >= 65) statsAdj += 2;
+          else if (underPctStat >= 55) statsAdj += 1;
+          if (underPctStat <= 35) statsAdj -= 2;
+          else if (underPctStat <= 45) statsAdj -= 1;
+        } else if (overPctStat !== null) {
+          if (overPctStat >= 68) statsAdj -= 2;
+          else if (overPctStat >= 60) statsAdj -= 1;
+          if (overPctStat <= 35) statsAdj += 1;
+        }
+        if (expGoals !== null) {
+          if (expGoals <= 2.1) statsAdj += 1;
+          else if (expGoals >= 3.4) statsAdj -= 1;
+        }
+      }
+
+      adj += clamp(statsAdj, -2, 2);
+    }
+
+    if (market === "BTTS") {
+      const yes = pick === "Y" || pick === "YES";
+      let statsAdj = 0;
+      const bttsPctStat = safeAverage([
+        getTeamValue(statsHome, "btts_pct", "home"),
+        getTeamValue(statsAway, "btts_pct", "away"),
+      ]);
+      const failPctStat = safeAverage([
+        getTeamValue(statsHome, "fail_pct", "home"),
+        getTeamValue(statsAway, "fail_pct", "away"),
+      ]);
+      const cleanPctStat = safeAverage([
+        getTeamValue(statsHome, "clean_pct", "home"),
+        getTeamValue(statsAway, "clean_pct", "away"),
+      ]);
+
+      if (yes) {
+        if (bttsPctStat !== null) {
+          if (bttsPctStat >= 68) statsAdj += 2;
+          else if (bttsPctStat >= 60) statsAdj += 1;
+          if (bttsPctStat <= 32) statsAdj -= 2;
+          else if (bttsPctStat <= 40) statsAdj -= 1;
+        }
+        if (failPctStat !== null && failPctStat >= 45) statsAdj -= 1;
+        if (cleanPctStat !== null && cleanPctStat >= 45) statsAdj -= 1;
+      } else {
+        if (bttsPctStat !== null) {
+          if (bttsPctStat <= 32) statsAdj += 2;
+          else if (bttsPctStat <= 40) statsAdj += 1;
+          if (bttsPctStat >= 68) statsAdj -= 2;
+          else if (bttsPctStat >= 60) statsAdj -= 1;
+        }
+        if (failPctStat !== null && failPctStat >= 45) statsAdj += 1;
+        if (cleanPctStat !== null && cleanPctStat >= 45) statsAdj += 1;
+      }
+
+      adj += clamp(statsAdj, -2, 2);
+    }
+
+    if (market === "1X2") {
+      let statsAdj = 0;
+      const formHome = formScore(statsHome);
+      const formAway = formScore(statsAway);
+
+      if (pick === "1") {
+        const winPct = getTeamValue(statsHome, "win_pct", "home");
+        const losePct = getTeamValue(statsAway, "lose_pct", "away");
+        const support = safeAverage([winPct, losePct]);
+        if (support !== null) {
+          if (support >= 68) statsAdj += 1;
+          if (support >= 76) statsAdj += 1;
+          if (support <= 42) statsAdj -= 1;
+        }
+        if (formHome !== null && formAway !== null) {
+          const diff = formHome - formAway;
+          if (diff >= 1.0) statsAdj += 1;
+          else if (diff <= -1.0) statsAdj -= 1;
+        }
+      } else if (pick === "2") {
+        const winPct = getTeamValue(statsAway, "win_pct", "away");
+        const losePct = getTeamValue(statsHome, "lose_pct", "home");
+        const support = safeAverage([winPct, losePct]);
+        if (support !== null) {
+          if (support >= 68) statsAdj += 1;
+          if (support >= 76) statsAdj += 1;
+          if (support <= 42) statsAdj -= 1;
+        }
+        if (formHome !== null && formAway !== null) {
+          const diff = formAway - formHome;
+          if (diff >= 1.0) statsAdj += 1;
+          else if (diff <= -1.0) statsAdj -= 1;
+        }
+      } else if (pick === "X") {
+        const drawPctHome = getTeamValue(statsHome, "draw_pct", "home");
+        const drawPctAway = getTeamValue(statsAway, "draw_pct", "away");
+        const drawSupport = safeAverage([drawPctHome, drawPctAway]);
+        if (drawSupport !== null) {
+          if (drawSupport >= 36) statsAdj += 1;
+          if (drawSupport >= 42) statsAdj += 1;
+          if (drawSupport <= 24) statsAdj -= 1;
+        }
+      }
+
+      adj += clamp(statsAdj, -2, 2);
+    }
   }
 
   // --- H2H procente (NOVO): koristimo ih samo kad imamo ≥4 FT meča ---


### PR DESCRIPTION
## Summary
- parse API-Football team statistics into compact `meta.stats.home/away` payloads during cron enrichment
- adjust value-bet confidence tweaks to incorporate averages, BTTS/OU percentages, and form from the new stats blocks
- document the optional schema so future jobs know which keys are available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cadf4dc26c83228cd9842be4a7ca43