### PR TITLE
Derive crypto vote thresholds from realized volatility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ default window is **75 minutes**. Operations can adjust it without editing the
 workflow by defining the repository variable `SNAPSHOT_GUARD_MINUTES`
 (`Settings → Secrets and variables → Actions`).
 
+## Crypto signal volatility tuning
+
+`buildSignals` now derives its intraday vote thresholds from realized log
+volatility so that 30m/1h/4h votes scale with current market conditions. The
+per-timeframe multipliers can be adjusted without redeploying by setting the
+following environment variables:
+
+- `CRYPTO_VOL_MULT_M30` (default **0.35**)
+- `CRYPTO_VOL_MULT_H1` (default **0.30**)
+- `CRYPTO_VOL_MULT_H4` (default **0.25**)
+
+Each multiplier scales the 60-sample log-volatility (expressed in percentage
+points) for its timeframe. Positive values increase or decrease sensitivity,
+while blank/invalid values fall back to the defaults above. If the volatility
+series is unavailable the engine reuses the legacy static thresholds or the
+values provided through `opts.thresh` for compatibility.
+
 ## Value bets meta stats schema
 
 `/api/cron/enrich` now persists a compact stats payload for each team under

--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -20,6 +20,11 @@ function envList(name, def) {
   if (!s) return def;
   return s.split(",").map(x=>x.trim().toUpperCase()).filter(Boolean);
 }
+function positiveOrDefault(value, fallback) {
+  const n = Number(value);
+  if (Number.isFinite(n) && n > 0) return n;
+  return Number.isFinite(fallback) && fallback > 0 ? fallback : 1;
+}
 
 /* ---------------- main ---------------- */
 export async function buildSignals(opts = {}) {
@@ -29,7 +34,24 @@ export async function buildSignals(opts = {}) {
   const minMcap = Number(opts.minMcap ?? envNum("CRYPTO_MIN_MCAP_USD", 200_000_000));
   const quorum = Number(opts.quorum ?? envInt("CRYPTO_QUORUM_VOTES", 3));
   const cgTop = Number(opts.binanceTop ?? envInt("CRYPTO_BINANCE_TOP", 150)); // koristi se kao top-N po MCAP
-  const thresh = opts.thresh || { m30: 0.2, h1: 0.3, h4: 0.5, d24: 0.0, d7: 0.0 };
+  const baseThresh = opts?.thresh || {};
+  const fallbackThresh = {
+    m30: toNum(baseThresh.m30, 0.2),
+    h1: toNum(baseThresh.h1, 0.3),
+    h4: toNum(baseThresh.h4, 0.5),
+    d24: toNum(baseThresh.d24, 0.0),
+    d7: toNum(baseThresh.d7, 0.0),
+  };
+  const envVolMult = {
+    m30: envNum("CRYPTO_VOL_MULT_M30", 0.35),
+    h1: envNum("CRYPTO_VOL_MULT_H1", 0.3),
+    h4: envNum("CRYPTO_VOL_MULT_H4", 0.25),
+  };
+  const volMultipliers = {
+    m30: positiveOrDefault(opts?.volMultipliers?.m30, envVolMult.m30),
+    h1: positiveOrDefault(opts?.volMultipliers?.h1, envVolMult.h1),
+    h4: positiveOrDefault(opts?.volMultipliers?.h4, envVolMult.h4),
+  };
 
   const levelsEnable = envBool("CRYPTO_LEVELS_ENABLE", true);
   const atrPeriod = envInt("CRYPTO_ATR_PERIOD", 14);
@@ -117,7 +139,13 @@ export async function buildSignals(opts = {}) {
     };
     if (requireIntraday && (!isFiniteNumber(deltas.m30_pct) || !isFiniteNumber(deltas.h4_pct))) return null;
 
-    const votes = votePack(deltas, thresh);
+    const realizedVol = {
+      m30: computeLogReturnVolatilityFromKlines(ex.k30, 60),
+      h1: computeLogReturnVolatilityFromKlines(ex.k1h, 60),
+      h4: computeLogReturnVolatilityFromKlines(ex.k4h, 60),
+    };
+    const thresholds = deriveVolatilityThresholds(realizedVol, volMultipliers, fallbackThresh);
+    const votes = votePack(deltas, thresholds);
     const available = [deltas.m30_pct, deltas.h1_pct, deltas.h4_pct, deltas.d24_pct, deltas.d7_pct].filter(isFiniteNumber).length;
     const need = Math.max(3, Math.min(quorum, available));
     const pos = [votes.m30, votes.h1, votes.h4, votes.d24, votes.d7].filter(v => v === +1).length;
@@ -451,6 +479,28 @@ function computeRealizedVolatilityFromKlines(klines, lookback = 30) {
   if (!Number.isFinite(variance) || variance < 0) return NaN;
   return Math.sqrt(variance) * 100;
 }
+function computeLogReturnVolatilityFromKlines(klines, lookback = 60) {
+  if (!Array.isArray(klines) || klines.length < 2) return NaN;
+  const closes = klines.map((k) => toNum(k.close)).filter((v) => isFiniteNumber(v) && v > 0);
+  if (closes.length < 2) return NaN;
+  const effectiveLookback = Math.max(1, Math.min(lookback, closes.length - 1));
+  const start = closes.length - effectiveLookback;
+  const rets = [];
+  for (let i = start; i < closes.length; i++) {
+    const prev = closes[i - 1];
+    const curr = closes[i];
+    if (!isFiniteNumber(prev) || !isFiniteNumber(curr) || prev <= 0) continue;
+    const r = Math.log(curr / prev);
+    if (Number.isFinite(r)) rets.push(r);
+  }
+  if (rets.length < 2) return NaN;
+  const mean = rets.reduce((a, b) => a + b, 0) / rets.length;
+  let variance = 0;
+  for (const r of rets) variance += (r - mean) ** 2;
+  variance = variance / Math.max(1, rets.length - 1);
+  if (!Number.isFinite(variance) || variance < 0) return NaN;
+  return Math.sqrt(variance) * 100;
+}
 function computeHurstExponentFromKlines(klines, lookback = 120) {
   if (!Array.isArray(klines) || klines.length < 20) return NaN;
   const closes = klines.map((k) => toNum(k.close)).filter((v) => isFiniteNumber(v) && v > 0);
@@ -673,6 +723,24 @@ function clampPercent(x) {
   if (!Number.isFinite(n)) return 0;
   return Math.max(0, Math.min(100, Math.round(n)));
 }
+function deriveVolatilityThresholds(volMap, multipliers, fallback) {
+  const base = typeof fallback === "object" && fallback ? { ...fallback } : {};
+  for (const tf of ["m30", "h1", "h4"]) {
+    const vol = Number(volMap?.[tf]);
+    const mult = Number(multipliers?.[tf]);
+    if (Number.isFinite(vol) && vol >= 0 && Number.isFinite(mult) && mult > 0) {
+      const thr = vol * mult;
+      if (Number.isFinite(thr) && thr >= 0) {
+        base[tf] = thr;
+        continue;
+      }
+    }
+    if (!Object.prototype.hasOwnProperty.call(base, tf)) base[tf] = 0;
+  }
+  if (!Object.prototype.hasOwnProperty.call(base, "d24")) base.d24 = 0;
+  if (!Object.prototype.hasOwnProperty.call(base, "d7")) base.d7 = 0;
+  return base;
+}
 export function votePack(d, T) {
   const m30 = voteOne(d.m30_pct, T.m30);
   const h1  = voteOne(d.h1_pct,  T.h1);
@@ -684,7 +752,7 @@ export function votePack(d, T) {
 }
 export function voteOne(x, thr) {
   if (!isFiniteNumber(x)) return 0;
-  const t = Math.abs(thr);
+  const t = Number.isFinite(thr) ? Math.abs(thr) : 0;
   if (x >  +t) return +1;
   if (x <  -t) return -1;
   return 0;


### PR DESCRIPTION
## Summary
- derive per-timeframe vote thresholds from 60-sample log volatility instead of fixed constants
- make intraday volatility multipliers configurable via CRYPTO_VOL_MULT_* env overrides with safe fallbacks
- document the new volatility tuning knobs for crypto signals in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf3585db8832283b3f84dbfb8b92b