### PR TITLE
Enforce shared API-Football budget across cron jobs

### DIFF
--- a/lib/sources/apiFootball.js
+++ b/lib/sources/apiFootball.js
@@ -12,7 +12,13 @@
 const API_BASE =
   process.env.API_FOOTBALL_BASE || "https://v3.football.api-sports.io";
 const API_KEY =
-  process.env.API_FOOTBALL_KEY || process.env.NEXT_PUBLIC_API_FOOTBALL_KEY || "";
+  process.env.API_FOOTBALL_KEY ||
+  process.env.APIFOOTBALL_KEY ||
+  process.env.APISPORTS_KEY ||
+  process.env.APISPORTS_API_KEY ||
+  process.env.X_APISPORTS_KEY ||
+  process.env.NEXT_PUBLIC_API_FOOTBALL_KEY ||
+  "";
 
 function qs(params = {}) {
   const u = new URLSearchParams();
@@ -232,22 +238,41 @@ async function afxGetJson(
 }
 
 // ---- Praktični helper-i (za sledeće korake; niko ih još ne zove) ----
-async function afxOddsByFixture(fixtureId, { ttlSeconds = 3 * 3600 } = {}) {
+async function afxOddsByFixture(
+  fixtureId,
+  { cacheKey, ttlSeconds = 0, priority = "P2", skipOnNoBudget = true, headers } = {}
+) {
   if (!fixtureId) return null;
   const path = `/odds?fixture=${encodeURIComponent(fixtureId)}`;
   return afxGetJson(path, {
-    cacheKey: `af:odds:fixture:${fixtureId}:snap`,
+    cacheKey: cacheKey || `af:odds:fixture:${fixtureId}:snap`,
     ttlSeconds,
-    priority: "P2",
+    priority,
+    skipOnNoBudget,
+    headers,
   });
 }
 
-async function afxFixturesByDate(ymd, { ttlSeconds = 2 * 3600 } = {}) {
-  const path = `/fixtures?date=${encodeURIComponent(ymd)}`;
+async function afxFixturesByDate(
+  ymd,
+  {
+    cacheKey,
+    ttlSeconds = 2 * 3600,
+    priority = "P2",
+    skipOnNoBudget = true,
+    headers,
+    timezone,
+  } = {}
+) {
+  if (!ymd) return null;
+  const tz = timezone ? `&timezone=${encodeURIComponent(timezone)}` : "";
+  const path = `/fixtures?date=${encodeURIComponent(ymd)}${tz}`;
   return afxGetJson(path, {
-    cacheKey: `af:fixtures:${ymd}`,
+    cacheKey: cacheKey || `af:fixtures:${ymd}${timezone ? `:${timezone}` : ""}`,
     ttlSeconds,
-    priority: "P2",
+    priority,
+    skipOnNoBudget,
+    headers,
   });
 }
 
@@ -255,27 +280,41 @@ async function afxTeamStats(
   leagueId,
   teamId,
   season,
-  { ttlSeconds = 3 * 24 * 3600 } = {}
+  {
+    cacheKey,
+    ttlSeconds = 3 * 24 * 3600,
+    priority = "P3",
+    skipOnNoBudget = true,
+    headers,
+  } = {}
 ) {
   if (!leagueId || !teamId || !season) return null;
   const path = `/teams/statistics?league=${encodeURIComponent(
     leagueId
   )}&team=${encodeURIComponent(teamId)}&season=${encodeURIComponent(season)}`;
   return afxGetJson(path, {
-    cacheKey: `af:stats:team:${teamId}:lg:${leagueId}:ssn:${season}`,
+    cacheKey:
+      cacheKey || `af:stats:team:${teamId}:lg:${leagueId}:ssn:${season}`,
     ttlSeconds,
-    priority: "P3",
+    priority,
+    skipOnNoBudget,
+    headers,
   });
 }
 
-async function afxInjuries(teamId, { ttlSeconds = 24 * 3600 } = {}) {
+async function afxInjuries(
+  teamId,
+  { cacheKey, ttlSeconds = 24 * 3600, priority = "P1", skipOnNoBudget = true, headers } = {}
+) {
   if (!teamId) return null;
   const ymd = afxYmd();
   const path = `/injuries?team=${encodeURIComponent(teamId)}`;
   return afxGetJson(path, {
-    cacheKey: `af:inj:team:${teamId}:${ymd}`,
+    cacheKey: cacheKey || `af:inj:team:${teamId}:${ymd}`,
     ttlSeconds,
-    priority: "P1",
+    priority,
+    skipOnNoBudget,
+    headers,
   });
 }
 
@@ -283,27 +322,34 @@ async function afxH2H(
   homeId,
   awayId,
   last = 10,
-  { ttlSeconds = 7 * 24 * 3600 } = {}
+  { cacheKey, ttlSeconds = 7 * 24 * 3600, priority = "P3", skipOnNoBudget = true, headers } = {}
 ) {
   if (!homeId || !awayId) return null;
   const path = `/fixtures/headtohead?h2h=${encodeURIComponent(
     homeId
   )}-${encodeURIComponent(awayId)}&last=${encodeURIComponent(last)}`;
   return afxGetJson(path, {
-    cacheKey: `af:h2h:${homeId}-${awayId}:last:${last}`,
+    cacheKey: cacheKey || `af:h2h:${homeId}-${awayId}:last:${last}`,
     ttlSeconds,
-    priority: "P3",
+    priority,
+    skipOnNoBudget,
+    headers,
   });
 }
 
-async function afxLineups(fixtureId, { ttlSeconds = 2 * 3600 } = {}) {
+async function afxLineups(
+  fixtureId,
+  { cacheKey, ttlSeconds = 2 * 3600, priority = "P1", skipOnNoBudget = true, headers } = {}
+) {
   if (!fixtureId) return null;
   const ymd = afxYmd();
   const path = `/fixtures/lineups?fixture=${encodeURIComponent(fixtureId)}`;
   return afxGetJson(path, {
-    cacheKey: `af:lineups:${fixtureId}:${ymd}`,
+    cacheKey: cacheKey || `af:lineups:${fixtureId}:${ymd}`,
     ttlSeconds,
-    priority: "P1",
+    priority,
+    skipOnNoBudget,
+    headers,
   });
 }
 


### PR DESCRIPTION
## Summary
- extend the API-Football helper so every wrapper uses the shared cache/budget gate and recognizes more environment key aliases
- route refresh-odds through the helper, lower the default slot caps, and short-circuit when the shared budget is depleted
- migrate the locked-floats warm path, closing-capture, rebuild seeding, apply-learning finals fetches, and backfill-scores batching to the shared helper with budget-aware responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb2b84daec8322b74ba82c8fb117dc