### PR TITLE
Support multi-day history aggregation and shared ROI

### DIFF
--- a/lib/history-utils.js
+++ b/lib/history-utils.js
@@ -1,0 +1,39 @@
+// lib/history-utils.js
+
+/**
+ * Jednostavan ROI:
+ * - stake = 1 po picku
+ * - ako je result === "win" ili won===true → profit = (price_snapshot - 1)
+ * - ako je "loss" → profit = -1
+ * - ako nema rezultata → ignoriši (pending)
+ */
+export function computeROI(items) {
+  let played = 0, wins = 0, profit = 0, avgOdds = 0;
+  for (const e of (items || [])) {
+    const res = (e?.result || "").toString().toLowerCase();
+    const won = (e?.won === true) || /win/.test(res);
+    const lost = /loss|lose/.test(res);
+    const odds = Number(e?.price_snapshot) || Number(e?.odds?.price) || null;
+    if (won) {
+      played++;
+      wins++;
+      if (odds) {
+        profit += (odds - 1);
+        avgOdds += odds;
+      } else {
+        profit += 0;
+      }
+    } else if (lost) {
+      played++;
+      profit -= 1;
+      if (odds) avgOdds += odds;
+    }
+    // pending se preskače
+  }
+  const roi = played ? (profit / played) : 0;
+  const wr = played ? (wins / played) : 0;
+  const ao = played ? (avgOdds / played) : 0;
+  return { played, wins, profit, roi, winrate: wr, avg_odds: ao };
+}
+
+export default computeROI;

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -1,4 +1,6 @@
 // pages/api/history-roi.js
+import { computeROI } from "../../lib/history-utils";
+
 export const config = { api: { bodyParser: false } };
 
 /* ---------- KV ---------- */
@@ -44,30 +46,6 @@ function filterAllowed(arr) {
     if (!by.has(k)) by.set(k, e);
   }
   return Array.from(by.values());
-}
-
-/**
- * Jednostavan ROI:
- * - stake = 1 po picku
- * - ako je result === "win" ili won===true → profit = (price_snapshot - 1)
- * - ako je "loss" → profit = -1
- * - ako nema rezultata → ignoriši (pending)
- */
-function computeROI(items) {
-  let played = 0, wins = 0, profit = 0, avgOdds = 0;
-  for (const e of (items||[])) {
-    const res = (e?.result || "").toString().toLowerCase();
-    const won = (e?.won === true) || /win/.test(res);
-    const lost = /loss|lose/.test(res);
-    const odds = Number(e?.price_snapshot) || Number(e?.odds?.price) || null;
-    if (won) { played++; wins++; if (odds) { profit += (odds - 1); avgOdds += odds; } else { profit += 0; } }
-    else if (lost) { played++; profit -= 1; if (odds) avgOdds += odds; }
-    // pending se preskače
-  }
-  const roi = played ? (profit / played) : 0;
-  const wr = played ? (wins / played) : 0;
-  const ao = played ? (avgOdds / played) : 0;
-  return { played, wins, profit, roi, winrate: wr, avg_odds: ao };
 }
 
 export default async function handler(req, res) {


### PR DESCRIPTION
## Summary
- extract the ROI computation into a shared helper for reuse between history APIs
- refactor history day loading into a helper and add multi-day aggregation via the days query parameter
- include aggregated ROI metrics and queried day list in the history response while preserving filtering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbb413423483229cad40444aca2e04