### PR TITLE
Expose ROI summary in history API and panel

### DIFF
--- a/components/HistoryPanel.js
+++ b/components/HistoryPanel.js
@@ -5,12 +5,8 @@ import { useEffect, useMemo, useState } from "react";
 
 /**
  * HistoryPanel (always two columns)
- * - Left: Football history (unchanged behavior; list for last N days)
+ * - Left: Football history (Top-3 H2H snapshot for last N days)
  * - Right: Crypto summary (14d ROI) + Crypto history for a specific day (ymd) or today's date
- *
- * Props:
- *   - days: number (default 14)   -> football lookback
- *   - ymd:  string (YYYY-MM-DD)   -> crypto day; if omitted, uses today in TZ
  */
 
 const TZ = (process.env.NEXT_PUBLIC_TZ_DISPLAY || "Europe/Belgrade").trim() || "Europe/Belgrade";
@@ -24,7 +20,11 @@ function ymdInTZ(date, tz = TZ) {
 }
 
 function J(s) {
-  try { return JSON.parse(String(s || "")); } catch { return null; }
+  try {
+    return JSON.parse(String(s || ""));
+  } catch {
+    return null;
+  }
 }
 
 function coalesceArray(x) {
@@ -39,45 +39,93 @@ function coalesceArray(x) {
 
 const isValidYmd = (s) => /^\d{4}-\d{2}-\d{2}$/.test(String(s || ""));
 
-// --- Small helpers to format football items robustly (works with several shapes) ---
-function getFixtureId(it) {
-  return it?.fixture_id || it?.fixture?.id || it?.id || `${it?.league?.id || "?"}-${it?.kickoff || it?.kickoff_utc || it?.ts || Math.random()}`;
-}
-function getTeamsLabel(it) {
-  const a = it?.teams?.home?.name || it?.home?.name || it?.home_name || it?.home || it?.homeTeam || null;
-  const b = it?.teams?.away?.name || it?.away?.name || it?.away_name || it?.away || it?.awayTeam || null;
-  if (a || b) return `${a || "—"} vs ${b || "—"}`;
-  return it?.title || it?.name || "Match";
-}
-function getKickoff(it) {
-  const iso = it?.kickoff_utc || it?.kickoff || it?.fixture?.date || it?.datetime_local?.starting_at?.date_time || it?.time?.starting_at?.date_time;
-  return iso ? new Date(iso) : null;
-}
-function getMarket(it) {
-  const m = it?.market_key || it?.market || null;
-  return m ? String(m) : null;
-}
-function getPick(it) {
-  return it?.pick || it?.selection_label || it?.bet_pick || null;
-}
-function getPrice(it) {
-  const p = it?.price_snapshot ?? it?.price ?? it?.odds?.price ?? it?.decimal ?? it?.odd;
-  const n = Number(p);
+const toNumberOrNull = (value) => {
+  const n = Number(value);
   return Number.isFinite(n) ? n : null;
+};
+const parsePercentish = (value) => {
+  if (typeof value === "string") {
+    const s = value.trim();
+    if (s.endsWith("%")) {
+      const n = Number(s.slice(0, -1));
+      if (Number.isFinite(n)) return n / 100;
+    }
+  }
+  return toNumberOrNull(value);
+};
+function normalizeRoi(obj) {
+  if (!obj || typeof obj !== "object") return null;
+  const played = toNumberOrNull(obj.played ?? obj.decided ?? obj.settled);
+  const wins = toNumberOrNull(obj.wins ?? obj.win ?? obj.won);
+  let profit = toNumberOrNull(obj.profit);
+  const staked = toNumberOrNull(obj.staked ?? obj.played ?? obj.settled);
+  const returned = toNumberOrNull(obj.returned);
+  if (profit == null && staked != null && returned != null) profit = returned - staked;
+  let roi = parsePercentish(obj.roi);
+  if (roi == null && obj.roi_pct != null) roi = parsePercentish(obj.roi_pct);
+  if (roi == null && obj.roi_percent != null) roi = parsePercentish(obj.roi_percent);
+  if (roi == null && profit != null && staked) roi = staked !== 0 ? profit / staked : null;
+  const avgOdds = toNumberOrNull(obj.avg_odds ?? obj.avgOdds ?? obj.average_odds);
+  let winrate = parsePercentish(obj.winrate ?? obj.win_rate ?? obj.winRate);
+  if (winrate == null && wins != null && played) winrate = played ? wins / played : null;
+
+  const out = {
+    played: played != null ? played : null,
+    wins: wins != null ? wins : null,
+    profit: profit != null ? profit : null,
+    roi: roi != null ? roi : null,
+    avg_odds: avgOdds != null ? avgOdds : null,
+    winrate: winrate != null ? winrate : null,
+  };
+  if (typeof obj.source === "string" && obj.source) out.source = obj.source;
+
+  const has = Object.values(out).some((v) => v != null);
+  return has ? out : null;
 }
-function getResult(it) {
-  // Supports both history settled items and combined snapshots without result
-  return it?.result || (typeof it?.won !== "undefined" ? (it.won ? "win" : "loss") : null);
-}
+
+const ROI_SOURCE_LABEL = {
+  history: "KV snapshot",
+  "history-roi": "history-roi fallback",
+  computed: "computed from items",
+  aggregate: "aggregate (range)",
+};
+
+const formatInteger = (value) => (Number.isFinite(value) ? value : "—");
+const formatProfit = (value) =>
+  Number.isFinite(value) ? `${value >= 0 ? "+" : ""}${value.toFixed(2)}` : "—";
+const formatRoi = (value) => (Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : "—");
+const formatOdds = (value) => (Number.isFinite(value) ? value.toFixed(2) : "—");
+const formatRange = (range) => {
+  if (!range) return null;
+  const latest = typeof range.latest === "string" ? range.latest : null;
+  const earliest = typeof range.earliest === "string" ? range.earliest : null;
+  if (latest && earliest) {
+    if (latest === earliest) return latest;
+    return `${earliest} → ${latest}`;
+  }
+  return latest || earliest || null;
+};
 
 export default function HistoryPanel({ days = 14, ymd }) {
   const [items, setItems] = useState([]);
   const [err, setErr] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // --- Football history fetch (existing behavior) ---
+  const dayYmd = useMemo(() => (isValidYmd(ymd) ? ymd : ymdInTZ(new Date())), [ymd]);
+  const [historyInfo, setHistoryInfo] = useState({ range: null, latestYmd: null, daysUsed: days });
+  const [historyRoi, setHistoryRoi] = useState(null);
+  const [roiFallbackRequested, setRoiFallbackRequested] = useState(false);
+
+  const [cryptoData, setCryptoData] = useState(null);
+  const [cryptoStats, setCryptoStats] = useState(null);
+
+  // --- Football history fetch (Top-3 H2H snapshot) ---
   useEffect(() => {
     const ac = new AbortController();
+    setLoading(true);
+    setHistoryRoi(null);
+    setHistoryInfo({ range: null, latestYmd: null, daysUsed: days });
+    setRoiFallbackRequested(false);
     (async () => {
       try {
         const href = `/api/history?days=${encodeURIComponent(days)}`;
@@ -85,17 +133,42 @@ export default function HistoryPanel({ days = 14, ymd }) {
         let body;
         try {
           const ct = (r.headers.get("content-type") || "").toLowerCase();
-          body = ct.includes("application/json")
-            ? await r.json()
-            : await r.text().then((t) => J(t));
+          body = ct.includes("application/json") ? await r.json() : await r.text().then((t) => J(t));
         } catch {
           body = null;
         }
         const arr = coalesceArray(body) || coalesceArray(body?.history) || [];
         setItems(arr);
+        const roiCandidate = body?.roi ?? body;
+        const normalizedRaw = normalizeRoi(roiCandidate);
+        const normalizedRoi = normalizedRaw
+          ? {
+              ...normalizedRaw,
+              ...(roiCandidate && typeof roiCandidate.source === "string"
+                ? { source: roiCandidate.source }
+                : {}),
+            }
+          : null;
+        setHistoryRoi(normalizedRoi);
+
+        const range = body?.range && (body.range.latest || body.range.earliest)
+          ? body.range
+          : body?.ymd && isValidYmd(body.ymd)
+          ? { latest: body.ymd, earliest: body.ymd }
+          : null;
+        const serverDays = Number(body?.days);
+        const daysUsed = Number.isFinite(serverDays) && serverDays > 0 ? serverDays : days;
+        const latestFromRange =
+          (range && range.latest && isValidYmd(range.latest) ? range.latest : null) ||
+          (typeof body?.ymd === "string" && isValidYmd(body.ymd) ? body.ymd : null) ||
+          (arr.find((it) => typeof it?.ymd === "string" && isValidYmd(it.ymd))?.ymd ?? null);
+        setHistoryInfo({ range, latestYmd: latestFromRange, daysUsed });
         setErr(null);
       } catch (e) {
         setErr(String(e?.message || e));
+        setItems([]);
+        setHistoryRoi(null);
+        setHistoryInfo({ range: null, latestYmd: null, daysUsed: days });
       } finally {
         setLoading(false);
       }
@@ -103,17 +176,47 @@ export default function HistoryPanel({ days = 14, ymd }) {
     return () => ac.abort();
   }, [days]);
 
+  // Fallback ROI fetch via /api/history-roi if API snapshot lacks ROI
+  useEffect(() => {
+    if (historyRoi || roiFallbackRequested) return;
+    const fallbackYmd =
+      (historyInfo?.latestYmd && isValidYmd(historyInfo.latestYmd) ? historyInfo.latestYmd : null) ||
+      (isValidYmd(dayYmd) ? dayYmd : null);
+    if (!fallbackYmd) return;
+    const ac = new AbortController();
+    setRoiFallbackRequested(true);
+    (async () => {
+      try {
+        const r = await fetch(`/api/history-roi?ymd=${fallbackYmd}`, {
+          cache: "no-store",
+          signal: ac.signal,
+        });
+        const j = await r.json().catch(() => null);
+        if (j?.ok) {
+          const normalized = normalizeRoi(j);
+          if (normalized) {
+            setHistoryRoi({ ...normalized, source: "history-roi" });
+          }
+        }
+      } catch {
+        /* noop */
+      }
+    })();
+    return () => ac.abort();
+  }, [historyRoi, roiFallbackRequested, historyInfo?.latestYmd, dayYmd]);
+
   // --- Crypto (right column) ---
-  const dayYmd = useMemo(() => (isValidYmd(ymd) ? ymd : ymdInTZ(new Date())), [ymd]);
-  const [cryptoData, setCryptoData] = useState(null);
-  const [cryptoStats, setCryptoStats] = useState(null); // 14d ROI summary
+  const dayForCrypto = useMemo(() => dayYmd, [dayYmd]);
 
   // Daily items for the chosen day
   useEffect(() => {
     const ac = new AbortController();
     (async () => {
       try {
-        const r = await fetch(`/api/crypto-history-day?ymd=${dayYmd}`, { cache: "no-store", signal: ac.signal });
+        const r = await fetch(`/api/crypto-history-day?ymd=${dayForCrypto}`, {
+          cache: "no-store",
+          signal: ac.signal,
+        });
         const j = await r.json().catch(() => null);
         setCryptoData(j || { ok: false, items: [] });
       } catch {
@@ -121,7 +224,7 @@ export default function HistoryPanel({ days = 14, ymd }) {
       }
     })();
     return () => ac.abort();
-  }, [dayYmd]);
+  }, [dayForCrypto]);
 
   // 14-day summary (ROI/winrate) — computed on read
   useEffect(() => {
@@ -139,55 +242,137 @@ export default function HistoryPanel({ days = 14, ymd }) {
   }, []);
 
   // --- Render helpers ---
+  const historyRangeText = formatRange(historyInfo.range);
+  const historyDaysLabel = historyInfo?.daysUsed ?? days;
+  const detailsYmd =
+    (historyInfo?.latestYmd && isValidYmd(historyInfo.latestYmd) ? historyInfo.latestYmd : null) ||
+    (isValidYmd(dayYmd) ? dayYmd : null);
+  const detailHref = detailsYmd ? `/api/history-roi?ymd=${detailsYmd}` : null;
+  const profitClass = Number.isFinite(historyRoi?.profit)
+    ? historyRoi.profit >= 0
+      ? "text-emerald-400"
+      : "text-rose-400"
+    : "text-slate-100";
+  const roiClass = Number.isFinite(historyRoi?.roi)
+    ? historyRoi.roi >= 0
+      ? "text-emerald-400"
+      : "text-rose-400"
+    : "text-slate-100";
+  const roiSourceLabel = historyRoi?.source
+    ? ROI_SOURCE_LABEL[historyRoi.source] || historyRoi.source
+    : null;
+
+  const HistorySummary = (
+    <section className="mt-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-300">Top-3 H2H ROI</p>
+          <p className="text-[11px] text-slate-400">
+            Performance snapshot for the pinned Top-3 H2H bets
+          </p>
+        </div>
+        {detailHref ? (
+          <a
+            href={detailHref}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs font-medium text-sky-400 hover:text-sky-200 transition"
+            title="Open detailed per-day ROI JSON"
+          >
+            history-roi details ↗
+          </a>
+        ) : null}
+      </div>
+      <div className="mt-3 rounded-xl border border-[#1f253f] bg-[#151a2d] p-3">
+        {historyRoi ? (
+          <>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm sm:grid-cols-5">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-400">Played</dt>
+                <dd className="text-lg font-semibold text-white">{formatInteger(historyRoi.played)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-400">Wins</dt>
+                <dd className="text-lg font-semibold text-white">{formatInteger(historyRoi.wins)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-400">Profit</dt>
+                <dd className={`text-lg font-semibold ${profitClass}`}>{formatProfit(historyRoi.profit)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-400">ROI</dt>
+                <dd className={`text-lg font-semibold ${roiClass}`}>{formatRoi(historyRoi.roi)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-slate-400">Avg odds</dt>
+                <dd className="text-lg font-semibold text-white">{formatOdds(historyRoi.avg_odds)}</dd>
+              </div>
+            </dl>
+            <div className="mt-3 space-y-1 text-[11px] text-slate-400">
+              <div>
+                {roiSourceLabel ? `${roiSourceLabel}` : "Derived from history records"}
+                {historyDaysLabel ? ` · window: ${historyDaysLabel} day${historyDaysLabel === 1 ? "" : "s"}` : ""}
+                {historyRangeText ? ` · ${historyRangeText}` : ""}
+              </div>
+              <div>ROI metrics refer strictly to the Top-3 H2H selections.</div>
+            </div>
+          </>
+        ) : (
+          <div className="text-sm text-slate-400">
+            ROI metrics are not available for this Top-3 H2H window.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+
   const FootballList = (
     <div>
-      <h3 className="font-semibold">History — last {days} day(s)</h3>
+      <h3 className="font-semibold">History — last {historyDaysLabel} day(s)</h3>
+      {HistorySummary}
 
-      {loading && (
-        <div className="text-sm opacity-70 py-2">Loading…</div>
-      )}
-      {err && (
-        <div className="text-sm text-red-400 py-2">Error: {err}</div>
-      )}
+      {loading && <div className="py-2 text-sm opacity-70">Loading…</div>}
+      {err && <div className="py-2 text-sm text-red-400">Error: {err}</div>}
 
       {!loading && !err && (!items || items.length === 0) && (
-        <div className="text-sm opacity-70 py-2">No history for the selected period.</div>
+        <div className="py-2 text-sm opacity-70">No history for the selected period.</div>
       )}
 
       <div className="divide-y">
-        {items && items.map((it, idx) => {
-          const id = getFixtureId(it) + "__" + idx;
-          const title = getTeamsLabel(it);
-          const k = getKickoff(it);
-          const market = getMarket(it);
-          const pick = getPick(it);
-          const price = getPrice(it);
-          const result = getResult(it);
-          const ymdItem = it?.ymd || (k ? ymdInTZ(k) : null);
+        {items &&
+          items.map((it, idx) => {
+            const id = getFixtureId(it) + "__" + idx;
+            const title = getTeamsLabel(it);
+            const k = getKickoff(it);
+            const market = getMarket(it);
+            const pick = getPick(it);
+            const price = getPrice(it);
+            const result = getResult(it);
+            const ymdItem = it?.ymd || (k ? ymdInTZ(k) : null);
 
-          return (
-            <div key={id} className="py-3">
-              <div className="flex items-baseline justify-between">
-                <div className="font-medium">{title}</div>
-                <div className="text-xs opacity-70">{ymdItem || ""}</div>
+            return (
+              <div key={id} className="py-3">
+                <div className="flex items-baseline justify-between">
+                  <div className="font-medium">{title}</div>
+                  <div className="text-xs opacity-70">{ymdItem || ""}</div>
+                </div>
+                <div className="text-slate-300">
+                  {market}
+                  {market ? " → " : ""}
+                  {pick}
+                  {Number.isFinite(price) ? ` (${price.toFixed(2)})` : ""}
+                  {result ? ` · ${result}` : ""}
+                </div>
               </div>
-              <div className="text-slate-300">
-                {market}
-                {market ? " → " : ""}
-                {pick}
-                {Number.isFinite(price) ? ` (${price.toFixed(2)})` : ""}
-                {result ? ` · ${result}` : ""}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
       </div>
     </div>
   );
 
   // Always two columns: left football, right crypto
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       <div className="min-w-0">{FootballList}</div>
       <div className="min-w-0">
         <section>
@@ -195,20 +380,20 @@ export default function HistoryPanel({ days = 14, ymd }) {
 
           {/* 14d ROI summary */}
           {cryptoStats?.ok ? (
-            <div className="text-sm opacity-80 mb-3">
+            <div className="mb-3 text-sm opacity-80">
               14d decided: {cryptoStats.decided ?? 0}
               {" · "}win-rate: {cryptoStats.win_rate_pct ?? "—"}%
               {" · "}avg RR: {typeof cryptoStats.avg_rr === "number" ? cryptoStats.avg_rr.toFixed(3) : "—"}
               {" · "}median RR: {cryptoStats.median_rr ?? "—"}
             </div>
           ) : (
-            <div className="text-sm opacity-60 mb-3">—</div>
+            <div className="mb-3 text-sm opacity-60">—</div>
           )}
 
           {/* Per-day items */}
           {cryptoData?.ok && Array.isArray(cryptoData.items) && cryptoData.items.length > 0 ? (
             <>
-              <div className="text-sm opacity-80 mb-2">
+              <div className="mb-2 text-sm opacity-80">
                 decided: {cryptoData.totals?.decided ?? 0}
                 {" · "}win-rate: {cryptoData.totals?.win_rate_pct ?? "—"}%
                 {" · "}avg RR: {typeof cryptoData.totals?.avg_rr === "number" ? cryptoData.totals.avg_rr.toFixed(3) : "—"}
@@ -218,9 +403,12 @@ export default function HistoryPanel({ days = 14, ymd }) {
                 {cryptoData.items.map((it) => (
                   <li key={it.id} className="py-2">
                     <b>{it.symbol}</b>{" "}
-                    <span className="opacity-70 text-xs">({it.exchange || "—"})</span>
-                    {" · "}{it.side || "—"}{" · "}RR={it.rr ?? "—"}
-                    {" → "}<b>{it.outcome || "pending"}</b>
+                    <span className="text-xs opacity-70">({it.exchange || "—"})</span>
+                    {" · "}
+                    {it.side || "—"}
+                    {" · "}RR={it.rr ?? "—"}
+                    {" → "}
+                    <b>{it.outcome || "pending"}</b>
                     {typeof it.realized_rr === "number" ? ` (realized ${it.realized_rr.toFixed(3)})` : ""}
                   </li>
                 ))}
@@ -233,4 +421,56 @@ export default function HistoryPanel({ days = 14, ymd }) {
       </div>
     </div>
   );
+}
+
+// --- Small helpers to format football items robustly (works with several shapes) ---
+function getFixtureId(it) {
+  return (
+    it?.fixture_id ||
+    it?.fixture?.id ||
+    it?.id ||
+    `${it?.league?.id || "?"}-${it?.kickoff || it?.kickoff_utc || it?.ts || Math.random()}`
+  );
+}
+function getTeamsLabel(it) {
+  const a =
+    it?.teams?.home?.name ||
+    it?.home?.name ||
+    it?.home_name ||
+    it?.home ||
+    it?.homeTeam ||
+    null;
+  const b =
+    it?.teams?.away?.name ||
+    it?.away?.name ||
+    it?.away_name ||
+    it?.away ||
+    it?.awayTeam ||
+    null;
+  if (a || b) return `${a || "—"} vs ${b || "—"}`;
+  return it?.title || it?.name || "Match";
+}
+function getKickoff(it) {
+  const iso =
+    it?.kickoff_utc ||
+    it?.kickoff ||
+    it?.fixture?.date ||
+    it?.datetime_local?.starting_at?.date_time ||
+    it?.time?.starting_at?.date_time;
+  return iso ? new Date(iso) : null;
+}
+function getMarket(it) {
+  const m = it?.market_key || it?.market || null;
+  return m ? String(m) : null;
+}
+function getPick(it) {
+  return it?.pick || it?.selection_label || it?.bet_pick || null;
+}
+function getPrice(it) {
+  const p = it?.price_snapshot ?? it?.price ?? it?.odds?.price ?? it?.decimal ?? it?.odd;
+  const n = Number(p);
+  return Number.isFinite(n) ? n : null;
+}
+function getResult(it) {
+  return it?.result || (typeof it?.won !== "undefined" ? (it.won ? "win" : "loss") : it?.outcome || null);
 }

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -6,42 +6,62 @@ function kvBackends() {
   const out = [];
   const aU = process.env.KV_REST_API_URL, aT = process.env.KV_REST_API_TOKEN;
   const bU = process.env.UPSTASH_REDIS_REST_URL, bT = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (aU && aT) out.push({ flavor:"vercel-kv", url:aU.replace(/\/+$/,""), tok:aT });
-  if (bU && bT) out.push({ flavor:"upstash-redis", url:bU.replace(/\/+$/,""), tok:bT });
+  if (aU && aT) out.push({ flavor: "vercel-kv", url: aU.replace(/\/+$/, ""), tok: aT });
+  if (bU && bT) out.push({ flavor: "upstash-redis", url: bU.replace(/\/+$/, ""), tok: bT });
   return out;
 }
 async function kvGETraw(key, trace) {
   for (const b of kvBackends()) {
     try {
-      const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`,{ headers:{ Authorization:`Bearer ${b.tok}` }, cache:"no-store" });
-      const j = await r.json().catch(()=>null);
+      const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`, {
+        headers: { Authorization: `Bearer ${b.tok}` },
+        cache: "no-store",
+      });
+      const j = await r.json().catch(() => null);
       const raw = typeof j?.result === "string" ? j.result : null;
-      trace && trace.push({ get:key, ok:r.ok, flavor:b.flavor, hit:!!raw });
+      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: !!raw });
       if (!r.ok) continue;
-      return { raw, flavor:b.flavor };
-    } catch (e) { trace && trace.push({ get:key, ok:false, err:String(e?.message||e) }); }
+      return { raw, flavor: b.flavor };
+    } catch (e) {
+      trace && trace.push({ get: key, ok: false, err: String(e?.message || e) });
+    }
   }
-  return { raw:null, flavor:null };
+  return { raw: null, flavor: null };
 }
 
 /* ---------- helpers ---------- */
-const J = s=>{ try{ return JSON.parse(String(s||"")); }catch{ return null; } };
-const isValidYmd = (s)=> /^\d{4}-\d{2}-\d{2}$/.test(String(s||""));
-const onlyMarketsCSV = (process.env.HISTORY_ALLOWED_MARKETS || "h2h").split(",").map(s=>s.trim().toLowerCase()).filter(Boolean);
+const J = (s) => {
+  try {
+    return JSON.parse(String(s || ""));
+  } catch {
+    return null;
+  }
+};
+const isValidYmd = (s) => /^\d{4}-\d{2}-\d{2}$/.test(String(s || ""));
+const onlyMarketsCSV = (process.env.HISTORY_ALLOWED_MARKETS || "h2h")
+  .split(",")
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
 const allowSet = new Set(onlyMarketsCSV.length ? onlyMarketsCSV : ["h2h"]);
-const arrFromAny = x => Array.isArray(x) ? x
-  : (x && typeof x==="object" && Array.isArray(x.items)) ? x.items
-  : (x && typeof x==="object" && Array.isArray(x.history)) ? x.history
-  : (x && typeof x==="object" && Array.isArray(x.list)) ? x.list : [];
-const dedupKey = e => `${e?.fixture_id||e?.id||"?"}__${String(e?.market_key||"").toLowerCase()}__${String(e?.pick||"").toLowerCase()}`;
+const arrFromAny = (x) =>
+  Array.isArray(x)
+    ? x
+    : x && typeof x === "object" && Array.isArray(x.items)
+    ? x.items
+    : x && typeof x === "object" && Array.isArray(x.history)
+    ? x.history
+    : x && typeof x === "object" && Array.isArray(x.list)
+    ? x.list
+    : [];
+const dedupKey = (e) =>
+  `${e?.fixture_id || e?.id || "?"}__${String(e?.market_key || "").toLowerCase()}__${String(
+    e?.pick || ""
+  ).toLowerCase()}`;
 
-/**
- * Filtriraj na dozvoljene markete (default: samo h2h), zadrži osnovna polja.
- */
 function filterAllowed(arr) {
   const by = new Map();
-  for (const e of (arr||[])) {
-    const mkey = String(e?.market_key||"").toLowerCase();
+  for (const e of arr || []) {
+    const mkey = String(e?.market_key || "").toLowerCase();
     if (!allowSet.has(mkey)) continue;
     const k = dedupKey(e);
     if (!by.has(k)) by.set(k, e);
@@ -49,37 +69,287 @@ function filterAllowed(arr) {
   return Array.from(by.values());
 }
 
+const toNumberOrNull = (val) => {
+  const n = Number(val);
+  return Number.isFinite(n) ? n : null;
+};
+const parsePercentish = (val) => {
+  if (typeof val === "string") {
+    const s = val.trim();
+    if (s.endsWith("%")) {
+      const n = Number(s.slice(0, -1));
+      if (Number.isFinite(n)) return n / 100;
+    }
+  }
+  return toNumberOrNull(val);
+};
+const firstNumber = (...vals) => {
+  for (const v of vals) {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+};
+const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
+
+function ensureItemsHaveYmd(items, ymd) {
+  if (!ymd) return Array.isArray(items) ? items.slice() : [];
+  const out = [];
+  for (const it of Array.isArray(items) ? items : []) {
+    if (it && typeof it === "object") {
+      if (it.ymd) {
+        out.push(it);
+      } else {
+        out.push({ ...it, ymd });
+      }
+    } else {
+      out.push(it);
+    }
+  }
+  return out;
+}
+
+function extractOdds(entry) {
+  const candidates = [
+    entry?.price_snapshot,
+    entry?.price,
+    entry?.decimal,
+    entry?.odd,
+    entry?.odds?.price,
+    entry?.snapshot?.price,
+  ];
+  for (const c of candidates) {
+    const n = Number(c);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return null;
+}
+
+function computeROIstats(items) {
+  let played = 0;
+  let wins = 0;
+  let profit = 0;
+  let avgOdds = 0;
+  for (const e of Array.isArray(items) ? items : []) {
+    const rawRes = (e?.result ?? e?.outcome ?? "").toString().toLowerCase();
+    const won = e?.won === true || /win/.test(rawRes);
+    const lost = (e?.won === false && !won) || /loss|lose/.test(rawRes);
+    if (!won && !lost) continue; // pending/void
+    const odds = extractOdds(e);
+    played += 1;
+    if (won) {
+      wins += 1;
+      if (odds != null) {
+        profit += odds - 1;
+        avgOdds += odds;
+      }
+    } else if (lost) {
+      profit -= 1;
+      if (odds != null) avgOdds += odds;
+    }
+  }
+  const roi = played ? profit / played : 0;
+  const winrate = played ? wins / played : 0;
+  const avg_odds = played ? avgOdds / played : 0;
+  return { played, wins, profit, roi, winrate, avg_odds };
+}
+
+function toRoiObject(candidate, counts, items, sourceLabel) {
+  if (!candidate || typeof candidate !== "object") return null;
+  const played = toNumberOrNull(
+    firstNumber(
+      candidate.played,
+      candidate.decided,
+      candidate.settled,
+      counts?.settled,
+      counts?.decided
+    )
+  );
+  const wins = toNumberOrNull(firstNumber(candidate.wins, candidate.win, candidate.won, counts?.won));
+  const losses = toNumberOrNull(firstNumber(candidate.losses, candidate.lost, counts?.lost));
+  let profit = toNumberOrNull(candidate.profit);
+  const staked = toNumberOrNull(firstNumber(candidate.staked, candidate.played, counts?.settled));
+  const returned = toNumberOrNull(candidate.returned);
+  if (profit == null && staked != null && returned != null) profit = returned - staked;
+  let roiVal = parsePercentish(candidate.roi);
+  if (roiVal == null && candidate.roi_pct != null) roiVal = parsePercentish(candidate.roi_pct);
+  if (roiVal == null && candidate.roi_percent != null) roiVal = parsePercentish(candidate.roi_percent);
+  if (roiVal == null && profit != null && staked && staked !== 0) roiVal = profit / staked;
+  const avgOdds = toNumberOrNull(firstNumber(candidate.avg_odds, candidate.avgOdds, candidate.average_odds));
+  let winrate = parsePercentish(candidate.winrate);
+  if (winrate == null && candidate.win_rate != null) winrate = parsePercentish(candidate.win_rate);
+  if (winrate == null && candidate.winRate != null) winrate = parsePercentish(candidate.winRate);
+  if (winrate == null && wins != null && played) winrate = wins / played;
+
+  const out = {
+    played: played != null ? played : null,
+    wins: wins != null ? wins : null,
+    losses: losses != null ? losses : null,
+    profit: profit != null ? profit : null,
+    roi: roiVal != null ? roiVal : null,
+    avg_odds: avgOdds != null ? avgOdds : null,
+    winrate: winrate != null ? winrate : null,
+  };
+
+  if (sourceLabel) {
+    out.source = sourceLabel;
+  } else if (typeof candidate.source === "string" && candidate.source) {
+    out.source = candidate.source;
+  }
+
+  const hasValue = Object.values(out).some((v) => Number.isFinite(v));
+  if (!hasValue) return null;
+
+  if (Array.isArray(items) && items.length) {
+    const computed = computeROIstats(items);
+    if (!isFiniteNumber(out.played)) out.played = computed.played;
+    if (!isFiniteNumber(out.wins)) out.wins = computed.wins;
+    if (!isFiniteNumber(out.profit)) out.profit = computed.profit;
+    if (!isFiniteNumber(out.roi)) out.roi = computed.roi;
+    if (!isFiniteNumber(out.avg_odds)) out.avg_odds = computed.avg_odds;
+    if (!isFiniteNumber(out.winrate)) out.winrate = computed.winrate;
+  } else if (counts) {
+    if (!isFiniteNumber(out.played)) out.played = toNumberOrNull(counts.settled ?? counts.decided);
+    if (!isFiniteNumber(out.wins)) out.wins = toNumberOrNull(counts.won);
+  }
+
+  return out;
+}
+
+async function fetchHistoryRoiViaApi(req, ymd, trace) {
+  try {
+    const host =
+      req.headers["x-forwarded-host"] ||
+      req.headers.host ||
+      (req.headers["x-vercel-forwarded-for"] ? req.headers["x-vercel-forwarded-for"].split(",")[0] : null);
+    if (!host) return null;
+    const protoHeader = req.headers["x-forwarded-proto"] || "";
+    const proto = protoHeader ? protoHeader.split(",")[0] : host.includes("localhost") ? "http" : "https";
+    const url = `${proto}://${host}/api/history-roi?ymd=${encodeURIComponent(ymd)}`;
+    const r = await fetch(url, { cache: "no-store", headers: { "x-history-proxy": "1" } });
+    const j = await r.json().catch(() => null);
+    trace && trace.push({ fetch: "history-roi", url, ok: r.ok, status: r.status });
+    if (!r.ok || !j?.ok) return null;
+    const roi = toRoiObject(j, null, j?.items, "history-roi");
+    if (roi) return roi;
+    const computed = computeROIstats(j?.items || []);
+    return { ...computed, source: "history-roi" };
+  } catch (e) {
+    trace && trace.push({ fetch: "history-roi", ok: false, error: String(e?.message || e) });
+    return null;
+  }
+}
+
+async function loadDayHistory({ ymd, trace, req }) {
+  const histKey = `hist:${ymd}`;
+  const { raw: rawHist } = await kvGETraw(histKey, trace);
+  const parsedHist = J(rawHist);
+  let items = filterAllowed(arrFromAny(parsedHist));
+  let source = items.length ? histKey : null;
+  let counts = parsedHist && typeof parsedHist === "object" ? parsedHist.counts || null : null;
+  let roiCandidate = parsedHist && typeof parsedHist === "object" ? parsedHist.roi || parsedHist.stats?.roi || null : null;
+
+  if (!items.length) {
+    const combKey = `vb:day:${ymd}:combined`;
+    const { raw: rawComb } = await kvGETraw(combKey, trace);
+    const parsedComb = J(rawComb);
+    const combArr = arrFromAny(parsedComb);
+    items = filterAllowed(combArr);
+    source = items.length ? combKey : null;
+    if (!counts && parsedComb && typeof parsedComb === "object" && parsedComb.counts) {
+      counts = parsedComb.counts;
+    }
+    if (!roiCandidate && parsedComb && typeof parsedComb === "object" && parsedComb.roi) {
+      roiCandidate = parsedComb.roi;
+    }
+  }
+
+  const itemsWithYmd = ensureItemsHaveYmd(items, ymd);
+  let roi = toRoiObject(roiCandidate, counts, itemsWithYmd, roiCandidate ? "history" : null);
+
+  if (!roi) {
+    const fallback = await fetchHistoryRoiViaApi(req, ymd, trace);
+    if (fallback) {
+      roi = fallback;
+    }
+  }
+
+  if (!roi) {
+    const computed = computeROIstats(itemsWithYmd);
+    roi = { ...computed, source: "computed" };
+  } else {
+    const computed = computeROIstats(itemsWithYmd);
+    if (!isFiniteNumber(roi.played)) roi.played = computed.played;
+    if (!isFiniteNumber(roi.wins)) roi.wins = computed.wins;
+    if (!isFiniteNumber(roi.profit)) roi.profit = computed.profit;
+    if (!isFiniteNumber(roi.roi)) roi.roi = computed.roi;
+    if (!isFiniteNumber(roi.avg_odds)) roi.avg_odds = computed.avg_odds;
+    if (!isFiniteNumber(roi.winrate)) roi.winrate = computed.winrate;
+  }
+
+  return { ymd, items: itemsWithYmd, source, roi, counts };
+}
+
 export default async function handler(req, res) {
   try {
     const trace = [];
-    const qYmd = String(req.query.ymd||"").trim();
+    const qYmd = String(req.query.ymd || "").trim();
+    const qDays = Number.parseInt(String(req.query.days || "").trim(), 10);
     const ymd = isValidYmd(qYmd) ? qYmd : null;
 
-    if (!ymd) {
-      return res.status(200).json({ ok:false, error:"Provide ymd=YYYY-MM-DD" });
+    if (ymd) {
+      const day = await loadDayHistory({ ymd, trace, req });
+      return res.status(200).json({
+        ok: true,
+        ymd,
+        count: day.items.length,
+        source: day.source,
+        history: day.items,
+        roi: day.roi,
+        counts: day.counts || null,
+        debug: { trace, allowed: Array.from(allowSet) },
+      });
     }
 
-    // 1) Primarno: hist:<ymd>
-    const histKey = `hist:${ymd}`;
-    const { raw:rawHist } = await kvGETraw(histKey, trace);
-    const histArr = arrFromAny(J(rawHist));
-    let items = filterAllowed(histArr);
-    let source = items.length ? histKey : null;
-
-    // 2) Fallback: vb:day:<ymd>:combined (ali filtrirano na h2h)
-    if (!items.length) {
-      const combKey = `vb:day:${ymd}:combined`;
-      const { raw:rawComb } = await kvGETraw(combKey, trace);
-      const combArr = arrFromAny(J(rawComb));
-      items = filterAllowed(combArr);
-      source = items.length ? combKey : null;
+    const days = Number.isFinite(qDays) ? Math.max(1, Math.min(30, qDays)) : 7;
+    const today = new Date();
+    const ymds = [];
+    for (let i = 0; i < days; i++) {
+      const d = new Date(today);
+      d.setUTCDate(d.getUTCDate() - i);
+      const dayYmd = d.toISOString().slice(0, 10);
+      ymds.push(dayYmd);
     }
+
+    const combined = [];
+    const daily = [];
+    for (const dayYmd of ymds) {
+      const day = await loadDayHistory({ ymd: dayYmd, trace, req });
+      combined.push(...day.items);
+      daily.push({
+        ymd: day.ymd,
+        count: day.items.length,
+        source: day.source,
+        roi: day.roi,
+        counts: day.counts || null,
+      });
+    }
+
+    const aggregateRoi = computeROIstats(combined);
+    aggregateRoi.source = "aggregate";
 
     return res.status(200).json({
-      ok:true, ymd, count: items.length, source, history: items, debug:{ trace, allowed: Array.from(allowSet) }
+      ok: true,
+      mode: "range",
+      days,
+      range: { latest: ymds[0], earliest: ymds[ymds.length - 1] },
+      count: combined.length,
+      history: combined,
+      roi: aggregateRoi,
+      byDay: daily,
+      debug: { trace, allowed: Array.from(allowSet) },
     });
-
   } catch (e) {
-    return res.status(200).json({ ok:false, error:String(e?.message||e) });
+    return res.status(200).json({ ok: false, error: String(e?.message || e) });
   }
 }


### PR DESCRIPTION
## Summary
- normalize ROI data in `/api/history` responses, fall back to `/api/history-roi` when absent, and compute aggregate ROI for multi-day history requests
- update the history panel to consume the enriched ROI payload, trigger the fallback when needed, and render a dedicated Top-3 H2H ROI summary with styling and details link

## Testing
- `npm run lint` *(fails: Missing script "lint" in package.json)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb45544e08322bcde835f2675e05f