### PR TITLE
Align crypto expected move thresholds

### DIFF
--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -60,7 +60,7 @@ export async function buildSignals(opts = {}) {
   const levelsEnable = envBool("CRYPTO_LEVELS_ENABLE", true);
   const atrPeriod = envInt("CRYPTO_ATR_PERIOD", 14);
   const atrSL = envNum("CRYPTO_ATR_SL_MULT", 1.0);
-  const atrTP = envNum("CRYPTO_ATR_TP_MULT", 1.8);
+  const atrTP = Math.max(envNum("CRYPTO_ATR_TP_MULT", 1.8), 1.8);
   const levelsValidMin = envInt("CRYPTO_LEVELS_VALID_MIN", 90);
   const requireIntraday = envBool("CRYPTO_REQUIRE_INTRADAY", true);
 

--- a/pages/api/cron/crypto-watchdog.js
+++ b/pages/api/cron/crypto-watchdog.js
@@ -33,6 +33,9 @@ const {
   CRYPTO_HISTORY_MAX_IDS = "5000",
 } = process.env;
 
+const MIN_EXPECTED_MOVE_DEFAULT = 1.5;
+const MIN_EXPECTED_MOVE = normalizeMinExpectedMove(CRYPTO_MIN_EXPECTED_MOVE_PCT, MIN_EXPECTED_MOVE_DEFAULT);
+
 const CFG = {
   MIN_VOL: toNum(CRYPTO_MIN_VOL_USD, 50_000_000),
   MIN_MCAP: toNum(CRYPTO_MIN_MCAP_USD, 200_000_000),
@@ -41,7 +44,7 @@ const CFG = {
   BINANCE_TOP: clampInt(CRYPTO_BINANCE_TOP, 150, 20, 400),
 
   MIN_RR: toNum(CRYPTO_MIN_RR, 0),
-  MIN_EM: toNum(CRYPTO_MIN_EXPECTED_MOVE_PCT, 0),
+  MIN_EM: MIN_EXPECTED_MOVE,
   REQUIRE_H1H4: parseBool(CRYPTO_REQUIRE_H1_H4),
   INCLUDE_7D: parseBool(CRYPTO_INCLUDE_7D, true),
   PERSIST_SNAPSHOTS: clampInt(CRYPTO_PERSIST_SNAPSHOTS, 0, 0, 10),
@@ -128,6 +131,12 @@ function enforcePolicy(list, cfg) {
     out.push(it);
   }
   return out;
+}
+
+function normalizeMinExpectedMove(value, fallback) {
+  const parsed = toNum(value, fallback);
+  if (parsed <= 0) return fallback;
+  return Math.max(parsed, fallback);
 }
 
 /* ---------- persistence & dedup ---------- */

--- a/pages/api/crypto.js
+++ b/pages/api/crypto.js
@@ -28,6 +28,9 @@ const {
   CRYPTO_PRICE_DIVERGENCE_MAX_PCT = "0",
 } = process.env;
 
+const MIN_EXPECTED_MOVE_DEFAULT = 1.5;
+const MIN_EXPECTED_MOVE = normalizeMinExpectedMove(CRYPTO_MIN_EXPECTED_MOVE_PCT, MIN_EXPECTED_MOVE_DEFAULT);
+
 const CFG = {
   TOP_N: clampInt(CRYPTO_TOP_N, 3, 1, 10),
   MIN_VOL: toNum(CRYPTO_MIN_VOL_USD, 50_000_000),
@@ -39,7 +42,7 @@ const CFG = {
   FORCE_TTL: clampInt(CRYPTO_FORCE_THROTTLE_SEC, 240, 30, 3600),
 
   MIN_RR: toNum(CRYPTO_MIN_RR, 0),
-  MIN_EM: toNum(CRYPTO_MIN_EXPECTED_MOVE_PCT, 0),
+  MIN_EM: MIN_EXPECTED_MOVE,
   REQUIRE_H1H4: parseBool(CRYPTO_REQUIRE_H1_H4),
   INCLUDE_7D: parseBool(CRYPTO_INCLUDE_7D, true),
   PERSIST_SNAPSHOTS: clampInt(CRYPTO_PERSIST_SNAPSHOTS, 0, 0, 10),
@@ -187,6 +190,12 @@ function sendCompat(res, base, shape) {
   if (shape === "legacy") return res.status(200).json({ ok: out.ok, total: out.count, items: out.items, ...out });
   if (shape === "slim") return res.status(200).json(items);
   return res.status(200).json(out);
+}
+
+function normalizeMinExpectedMove(value, fallback) {
+  const parsed = toNum(value, fallback);
+  if (parsed <= 0) return fallback;
+  return Math.max(parsed, fallback);
 }
 
 /* ---------- Policy filter ---------- */


### PR DESCRIPTION
## Summary
- enforce a minimum ATR take-profit multiplier of 1.8 when loading `CRYPTO_ATR_TP_MULT`
- default the crypto API expected-move threshold to 1.5 via a normalizer
- reuse the same expected-move normalization in the watchdog cron job

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe4597b388322b151c6c3439f65c8