### PR TITLE
Add CoinGecko quota enforcement and graceful fallbacks

### DIFF
--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -239,7 +239,81 @@ export async function buildSignals(opts = {}) {
 }
 
 /* ---------------- CoinGecko markets ---------------- */
+const CG_QUOTA_MIN_LIMIT = 30;
+const CG_QUOTA_DAY_LIMIT = 300;
+
+export async function reserveCoinGeckoQuota(now = Date.now()) {
+  const url = process.env.UPSTASH_REDIS_REST_URL || "";
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || "";
+  if (!url || !token) return { minute: null, day: null };
+
+  const iso = new Date(now).toISOString();
+  const minuteSlot = iso.slice(0, 16).replace(/[-:T]/g, "");
+  const daySlot = iso.slice(0, 10).replace(/-/g, "");
+  const minuteKey = `crypto:cg:quota:minute:${minuteSlot}`;
+  const dayKey = `crypto:cg:quota:day:${daySlot}`;
+
+  const commands = [
+    ["INCR", minuteKey],
+    ["EXPIRE", minuteKey, "120", "NX"],
+    ["INCR", dayKey],
+    ["EXPIRE", dayKey, String(172800), "NX"],
+  ];
+
+  let r;
+  try {
+    r = await fetch(`${url}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(commands),
+      cache: "no-store",
+    });
+  } catch (cause) {
+    const err = new Error("coingecko_quota_reserve_failed");
+    err.code = "coingecko_quota_reserve_failed";
+    err.cause = cause;
+    throw err;
+  }
+
+  if (!r.ok) {
+    const txt = await r.text().catch(() => "");
+    const err = new Error(`coingecko_quota_reserve_failed:${r.status}`);
+    err.code = "coingecko_quota_reserve_failed";
+    err.details = { status: r.status, body: txt || null };
+    throw err;
+  }
+
+  const json = await r.json().catch(() => null);
+  const rows = Array.isArray(json?.result) ? json.result : json;
+  const minuteCount = Number(rows?.[0]?.result ?? rows?.[0]);
+  const dayCount = Number(rows?.[2]?.result ?? rows?.[2]);
+  if (!Number.isFinite(minuteCount) || !Number.isFinite(dayCount)) {
+    const err = new Error("coingecko_quota_parse_failed");
+    err.code = "coingecko_quota_parse_failed";
+    err.details = { json };
+    throw err;
+  }
+
+  if (minuteCount > CG_QUOTA_MIN_LIMIT || dayCount > CG_QUOTA_DAY_LIMIT) {
+    const err = new Error("coingecko_quota_exceeded");
+    err.code = "coingecko_quota_exceeded";
+    err.details = {
+      minuteCount,
+      dayCount,
+      minuteLimit: CG_QUOTA_MIN_LIMIT,
+      dayLimit: CG_QUOTA_DAY_LIMIT,
+    };
+    throw err;
+  }
+
+  return { minute: minuteCount, day: dayCount };
+}
+
 export async function fetchCoinGeckoMarkets(apiKey = "") {
+  await reserveCoinGeckoQuota();
   const url = new URL("https://api.coingecko.com/api/v3/coins/markets");
   url.searchParams.set("vs_currency", "usd");
   url.searchParams.set("order", "market_cap_desc");


### PR DESCRIPTION
## Summary
- add an Upstash-backed reserveCoinGeckoQuota helper that enforces per-minute and per-day CoinGecko quotas before issuing market fetches
- have the crypto API and cron watchdog fall back to cached snapshots when CoinGecko quota is exhausted and log handled outcomes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf0f877dc8322b1552bc347e87c9a