### PR TITLE
Use CoinGecko pro endpoint when API key present

### DIFF
--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -315,7 +315,11 @@ export async function reserveCoinGeckoQuota(now = Date.now()) {
 
 export async function fetchCoinGeckoMarkets(apiKey = "") {
   await reserveCoinGeckoQuota();
-  const url = new URL("https://api.coingecko.com/api/v3/coins/markets");
+  const hasApiKey = Boolean(apiKey);
+  const baseUrl = hasApiKey
+    ? "https://pro-api.coingecko.com/api/v3/coins/markets"
+    : "https://api.coingecko.com/api/v3/coins/markets";
+  const url = new URL(baseUrl);
   url.searchParams.set("vs_currency", "usd");
   url.searchParams.set("order", "market_cap_desc");
   url.searchParams.set("per_page", "250");
@@ -323,7 +327,7 @@ export async function fetchCoinGeckoMarkets(apiKey = "") {
   url.searchParams.set("sparkline", "false");
   url.searchParams.set("price_change_percentage", "1h,24h,7d");
   const headers = {};
-  if (apiKey) headers["x-cg-pro-api-key"] = apiKey;
+  if (hasApiKey) headers["x-cg-pro-api-key"] = apiKey;
 
   const r = await fetch(url, { headers, cache: "no-store" });
   const ct = (r.headers.get("content-type") || "").toLowerCase();


### PR DESCRIPTION
## Summary
- switch the CoinGecko markets fetcher to the pro API endpoint when a key is supplied while keeping the public endpoint fallback
- ensure the pro API header is only attached when an API key is actually present

## Testing
- npm test
- node --input-type=module - <<'EOF' (fails in container: fetch ENETUNREACH)
  import { fetchCoinGeckoMarkets } from "./lib/crypto-core.js";
  const data = await fetchCoinGeckoMarkets("");
  console.log(data.length);
EOF

------
https://chatgpt.com/codex/tasks/task_e_68cc0a32b37c832295797c776ae52ee8