### PR TITLE
Ensure crypto workflows fail on curl errors

### DIFF
--- a/.github/workflows/crypto-outcomes.yml
+++ b/.github/workflows/crypto-outcomes.yml
@@ -27,7 +27,7 @@ jobs:
           BASE_URL: ${{ secrets.BASE_URL }}
           CRON_KEY: ${{ secrets.CRON_KEY }}
         run: |
-          set -e
+          set -euo pipefail
           curl --fail --show-error --silent \
             "$BASE_URL/api/cron/crypto-outcomes?key=$CRON_KEY" \
             | tee /dev/stderr

--- a/.github/workflows/crypto-watchdog.yml
+++ b/.github/workflows/crypto-watchdog.yml
@@ -28,7 +28,7 @@ jobs:
           BASE_URL: ${{ secrets.BASE_URL }}
           CRON_KEY: ${{ secrets.CRON_KEY }}
         run: |
-          set -e
+          set -euo pipefail
           curl --fail --show-error --silent \
             "$BASE_URL/api/cron/crypto-watchdog?key=$CRON_KEY" \
             | tee /dev/stderr


### PR DESCRIPTION
## Summary
- enable `pipefail` in crypto outcomes workflow curl step to fail on curl errors
- enable `pipefail` in crypto watchdog workflow curl step to fail on curl errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc0f568ef483228dd037779498e300