### PR TITLE
Add cached Odds API helper with shared budget controls

### DIFF
--- a/__tests__/pages/api/odds-sports.test.js
+++ b/__tests__/pages/api/odds-sports.test.js
@@ -1,0 +1,116 @@
+jest.mock("../../../lib/sources/theOddsApi", () => ({
+  fetchOddsSnapshot: jest.fn(),
+}));
+
+const { fetchOddsSnapshot } = require("../../../lib/sources/theOddsApi");
+const { default: handler } = require("../../../pages/api/odds-sports");
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  process.env.ODDS_API_KEY = "test-key";
+  fetchOddsSnapshot.mockReset();
+});
+
+describe("API /api/odds-sports", () => {
+  it("maps cached snapshots into bookmaker payloads", async () => {
+    const kickoff = new Date("2024-05-14T18:00:00Z").toISOString();
+
+    fetchOddsSnapshot.mockResolvedValueOnce({
+      data: [
+        {
+          id: "evt-1",
+          home_team: "Team Home",
+          away_team: "Team Away",
+          commence_time: kickoff,
+          bookmakers: [
+            {
+              title: "TestBook",
+              markets: [
+                {
+                  key: "h2h",
+                  outcomes: [
+                    { name: "Team Home", price: 1.9 },
+                    { name: "Draw", price: 3.2 },
+                    { name: "Team Away", price: 4.1 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      fromCache: true,
+      exhausted: false,
+    });
+
+    const req = {
+      query: {
+        home: "Team Home",
+        away: "Team Away",
+        ts: kickoff,
+      },
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchOddsSnapshot).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload).toEqual({
+      bookmakers: [
+        {
+          name: "TestBook",
+          bets: [
+            {
+              name: "1X2",
+              values: [
+                { value: "HOME", odd: 1.9 },
+                { value: "DRAW", odd: 3.2 },
+                { value: "AWAY", odd: 4.1 },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("returns an empty bookmaker list with a budget message when quota is exhausted", async () => {
+    fetchOddsSnapshot.mockResolvedValue({
+      data: null,
+      exhausted: true,
+    });
+
+    const req = {
+      query: {
+        home: "Team Home",
+        away: "Team Away",
+        ts: "2024-05-14T18:00:00Z",
+      },
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchOddsSnapshot).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload).toEqual({
+      bookmakers: [],
+      message: "Daily odds API budget exhausted",
+    });
+  });
+});

--- a/lib/sources/apiFootball.js
+++ b/lib/sources/apiFootball.js
@@ -368,3 +368,7 @@ module.exports.afxInjuries = afxInjuries;
 module.exports.afxH2H = afxH2H;
 module.exports.afxLineups = afxLineups;
 module.exports.afxReadBudget = afxReadBudget;
+module.exports.afxCacheGet = afxCacheGet;
+module.exports.afxCacheSet = afxCacheSet;
+module.exports.afxBudgetConsume = afxBudgetConsume;
+module.exports.afxYmd = afxYmd;

--- a/lib/sources/theOddsApi.js
+++ b/lib/sources/theOddsApi.js
@@ -1,21 +1,152 @@
-// lib/sources/theOddsApi.js
-export async function fetchOdds(sportKey, regions = "eu", markets = "h2h,totals") {
-  const apiKey = process.env.ODDS_API_KEY;
-  if (!apiKey) throw new Error("Missing ODDS_API_KEY env var");
+import apiFootball from "./apiFootball";
 
-  const url = `https://api.the-odds-api.com/v4/sports/${encodeURIComponent(
-    sportKey
-  )}/odds/?apiKey=${encodeURIComponent(apiKey)}&regions=${regions}&markets=${markets}&dateFormat=iso&oddsFormat=decimal`;
+const {
+  afxCacheGet,
+  afxCacheSet,
+  afxBudgetConsume,
+  afxYmd,
+} = apiFootball || {};
 
+const DEFAULT_TTL_SECONDS = 10 * 60;
+const DAILY_LIMIT_RAW = Number(process.env.ODDS_API_DAILY_LIMIT);
+const DEFAULT_DAILY_LIMIT =
+  Number.isFinite(DAILY_LIMIT_RAW) && DAILY_LIMIT_RAW > 0
+    ? DAILY_LIMIT_RAW
+    : 15;
+const API_FOOTBALL_BUDGET_POOL_RAW = Number(
+  process.env.API_FOOTBALL_DAILY_BUDGET
+);
+const API_FOOTBALL_BUDGET_POOL =
+  Number.isFinite(API_FOOTBALL_BUDGET_POOL_RAW) && API_FOOTBALL_BUDGET_POOL_RAW > 0
+    ? API_FOOTBALL_BUDGET_POOL_RAW
+    : 5000;
+const BUDGET_COST = Math.max(
+  1,
+  Math.ceil(API_FOOTBALL_BUDGET_POOL / DEFAULT_DAILY_LIMIT)
+);
+const BUDGET_PRIORITY = "P2";
+
+function buildCacheKey(sportKey, regions, markets) {
+  return `oddsapi:snap:${sportKey}:${regions}:${markets}`;
+}
+
+function resolveYmd() {
+  if (typeof afxYmd === "function") return `odds:${afxYmd()}`;
+  return `odds:${new Date().toISOString().slice(0, 10)}`;
+}
+
+async function maybeReadCache(cacheKey, ttlSeconds) {
+  if (!cacheKey || ttlSeconds <= 0) return null;
+  if (typeof afxCacheGet !== "function") return null;
   try {
-    const res = await fetch(url);
-    const body = await res.text();
-    if (!res.ok) {
-      throw new Error(`Odds API fetch failed ${res.status}: ${body}`);
-    }
-    return JSON.parse(body);
-  } catch (e) {
-    console.error("fetchOdds error:", e.message, "url:", url);
-    throw e;
+    return await afxCacheGet(cacheKey);
+  } catch {
+    return null;
   }
 }
+
+async function maybeWriteCache(cacheKey, ttlSeconds, payload) {
+  if (!cacheKey || ttlSeconds <= 0) return false;
+  if (typeof afxCacheSet !== "function") return false;
+  try {
+    await afxCacheSet(cacheKey, payload, ttlSeconds);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function consumeBudget(budgetKey, budgetCost) {
+  if (typeof afxBudgetConsume !== "function") return { allowed: true };
+  try {
+    const allowed = await afxBudgetConsume(budgetKey, budgetCost, BUDGET_PRIORITY);
+    return { allowed };
+  } catch (err) {
+    // On KV errors allow the request to continue but surface diagnostic info.
+    return { allowed: true, error: err };
+  }
+}
+
+export async function fetchOddsSnapshot(
+  sportKey,
+  {
+    regions = "eu",
+    markets = "h2h",
+    ttlSeconds = DEFAULT_TTL_SECONDS,
+    fetcher = fetch,
+  } = {}
+) {
+  if (!sportKey) {
+    throw new Error("fetchOddsSnapshot requires a sportKey");
+  }
+
+  const apiKey = process.env.ODDS_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing ODDS_API_KEY env var");
+  }
+
+  const cacheKey = buildCacheKey(sportKey, regions, markets);
+  const cacheHit = await maybeReadCache(cacheKey, ttlSeconds);
+  if (cacheHit) {
+    return {
+      data: cacheHit,
+      fromCache: true,
+      exhausted: false,
+      cacheKey,
+    };
+  }
+
+  const budgetKey = resolveYmd();
+  const { allowed } = await consumeBudget(budgetKey, BUDGET_COST);
+  if (!allowed) {
+    return {
+      data: null,
+      fromCache: false,
+      exhausted: true,
+      cacheKey,
+      budgetKey,
+    };
+  }
+
+  const url = new URL(
+    `https://api.the-odds-api.com/v4/sports/${encodeURIComponent(
+      sportKey
+    )}/odds`
+  );
+  url.searchParams.set("apiKey", apiKey);
+  url.searchParams.set("regions", regions);
+  url.searchParams.set("markets", markets);
+  url.searchParams.set("dateFormat", "iso");
+  url.searchParams.set("oddsFormat", "decimal");
+
+  let responseText = "";
+  try {
+    const res = await fetcher(url.toString(), { cache: "no-store" });
+    responseText = await res.text();
+    if (!res.ok) {
+      throw new Error(
+        `Odds API fetch failed ${res.status}: ${responseText.slice(0, 240)}`
+      );
+    }
+    const payload = responseText ? JSON.parse(responseText) : null;
+    await maybeWriteCache(cacheKey, ttlSeconds, payload);
+    return {
+      data: payload,
+      fromCache: false,
+      exhausted: false,
+      cacheKey,
+      budgetKey,
+    };
+  } catch (err) {
+    const error = new Error(
+      `fetchOddsSnapshot error: ${err.message || err} url: ${url.toString()}`
+    );
+    error.cause = err;
+    error.body = responseText;
+    throw error;
+  }
+}
+
+export default {
+  fetchOddsSnapshot,
+};


### PR DESCRIPTION
## Summary
- expose the existing Upstash cache and budget helpers from the API-Football source so other modules can reuse them
- replace the Odds API client with a cached snapshot helper that shares a 15-call daily budget and surfaces cache hits
- refactor the /api/odds-sports route to consume cached snapshots, stop on exhausted quota, and add regression tests for cache hits and budget exhaustion

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1c5cbbc88322928fba22eefddacb