### PR TITLE
Sort history panel items by recency

### DIFF
--- a/__tests__/components/HistoryPanel.test.js
+++ b/__tests__/components/HistoryPanel.test.js
@@ -1,0 +1,31 @@
+import { sortAndLimitHistoryItems } from "../../components/HistoryPanel";
+
+describe("sortAndLimitHistoryItems", () => {
+  test("orders newest kickoff first before applying top limit", () => {
+    const rawItems = [
+      { fixture_id: "old", kickoff: "2024-06-10T12:00:00Z" },
+      { fixture_id: "newer", kickoff: "2024-06-10T15:00:00Z" },
+      { fixture_id: "old-day", kickoff: "2024-06-09T20:00:00Z" },
+    ];
+
+    const limited = sortAndLimitHistoryItems(rawItems, 2);
+    expect(limited.map((it) => it.fixture_id)).toEqual(["newer", "old"]);
+  });
+
+  test("falls back to ymd/slot ordering and keeps stability for same-slot items", () => {
+    const rawItems = [
+      { fixture_id: "day-old-am", ymd: "2024-06-09", slot: "am" },
+      { fixture_id: "day-old-pm", ymd: "2024-06-09", slot: "pm" },
+      { fixture_id: "new-am-a", ymd: "2024-06-10", slot: "am" },
+      { fixture_id: "new-am-b", ymd: "2024-06-10", slot: "am" },
+      { fixture_id: "new-pm", ymd: "2024-06-10", slot: "pm" },
+    ];
+
+    const limited = sortAndLimitHistoryItems(rawItems, 3);
+    expect(limited.map((it) => it.fixture_id)).toEqual([
+      "new-pm",
+      "new-am-a",
+      "new-am-b",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- derive a recency score for history items using kickoff timestamps and ymd/slot fallbacks before limiting the list
- keep ordering stable for items with the same derived timestamp so existing grouping is preserved
- add unit tests that cover the new sorting helper and ensure newly appended slot items surface when the history panel is capped

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc449b18a0832290bf0d82670356ed