### PR TITLE
Require CoinGecko API key for crypto markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ while blank/invalid values fall back to the defaults above. If the volatility
 series is unavailable the engine reuses the legacy static thresholds or the
 values provided through `opts.thresh` for compatibility.
 
+## CoinGecko Pro API requirement
+
+Both the `/api/crypto` endpoint and the `crypto-watchdog` cron rely on the
+CoinGecko Pro markets feed. Deployments must provide a valid
+`COINGECKO_API_KEY` environment variable; when it is missing the API now fails
+fast with a `coingecko_api_key_missing` error. Configure the variable in the
+hosting provider (for example Vercel project settings or GitHub Actions
+secrets) so the watchdog and public API remain operational.
+
 ## Value bets meta stats schema
 
 `/api/cron/enrich` now persists a compact stats payload for each team under

--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -314,20 +314,22 @@ export async function reserveCoinGeckoQuota(now = Date.now()) {
 }
 
 export async function fetchCoinGeckoMarkets(apiKey = "") {
+  const trimmedApiKey = typeof apiKey === "string" ? apiKey.trim() : "";
+  if (!trimmedApiKey) {
+    const err = new Error("coingecko_api_key_missing");
+    err.code = "coingecko_api_key_missing";
+    throw err;
+  }
+
   await reserveCoinGeckoQuota();
-  const hasApiKey = Boolean(apiKey);
-  const baseUrl = hasApiKey
-    ? "https://pro-api.coingecko.com/api/v3/coins/markets"
-    : "https://api.coingecko.com/api/v3/coins/markets";
-  const url = new URL(baseUrl);
+  const url = new URL("https://pro-api.coingecko.com/api/v3/coins/markets");
   url.searchParams.set("vs_currency", "usd");
   url.searchParams.set("order", "market_cap_desc");
   url.searchParams.set("per_page", "250");
   url.searchParams.set("page", "1");
   url.searchParams.set("sparkline", "false");
   url.searchParams.set("price_change_percentage", "1h,24h,7d");
-  const headers = {};
-  if (hasApiKey) headers["x-cg-pro-api-key"] = apiKey;
+  const headers = { "x-cg-pro-api-key": trimmedApiKey };
 
   const r = await fetch(url, { headers, cache: "no-store" });
   const ct = (r.headers.get("content-type") || "").toLowerCase();

--- a/pages/api/cron/crypto-watchdog.js
+++ b/pages/api/cron/crypto-watchdog.js
@@ -78,6 +78,13 @@ export default async function handler(req, res) {
         binanceTop: CFG.BINANCE_TOP,
       });
     } catch (err) {
+      if (isCoinGeckoApiKeyMissing(err)) {
+        console.error("[cron/crypto-watchdog] Missing CoinGecko API key", {
+          code: err?.code || null,
+          message: err?.message || null,
+        });
+        return res.status(500).json({ ok: false, error: "coingecko_api_key_missing" });
+      }
       if (isCoinGeckoQuotaError(err)) {
         const snapshot = await kvGetJSON(cacheKey);
         if (snapshot && Array.isArray(snapshot.items) && snapshot.items.length) {
@@ -185,6 +192,14 @@ function isCoinGeckoQuotaError(err) {
   const message = typeof err.message === "string" ? err.message : "";
   if (code === "coingecko_quota_exceeded") return true;
   return message.includes("coingecko_quota_exceeded");
+}
+
+function isCoinGeckoApiKeyMissing(err) {
+  if (!err) return false;
+  const code = typeof err.code === "string" ? err.code : "";
+  if (code === "coingecko_api_key_missing") return true;
+  const message = typeof err.message === "string" ? err.message : "";
+  return message.includes("coingecko_api_key_missing");
 }
 
 function quotaDetails(err) {

--- a/pages/api/crypto.js
+++ b/pages/api/crypto.js
@@ -92,6 +92,15 @@ export default async function handler(req, res) {
         binanceTop: CFG.BINANCE_TOP,
       });
     } catch (err) {
+      if (isCoinGeckoApiKeyMissing(err)) {
+        console.error("[api/crypto] Missing CoinGecko API key", {
+          code: err?.code || null,
+          message: err?.message || null,
+        });
+        return res
+          .status(500)
+          .json({ ok: false, error: "coingecko_api_key_missing" });
+      }
       if (isCoinGeckoQuotaError(err)) {
         const snapshot =
           (cached && Array.isArray(cached.items) && cached.items.length)
@@ -242,6 +251,14 @@ function isCoinGeckoQuotaError(err) {
   const message = typeof err.message === "string" ? err.message : "";
   if (code === "coingecko_quota_exceeded") return true;
   return message.includes("coingecko_quota_exceeded");
+}
+
+function isCoinGeckoApiKeyMissing(err) {
+  if (!err) return false;
+  const code = typeof err.code === "string" ? err.code : "";
+  if (code === "coingecko_api_key_missing") return true;
+  const message = typeof err.message === "string" ? err.message : "";
+  return message.includes("coingecko_api_key_missing");
 }
 
 function quotaDetails(err) {


### PR DESCRIPTION
## Summary
- require a CoinGecko Pro API key before fetching markets data and avoid falling back to the public endpoint
- return a clear `coingecko_api_key_missing` error from the crypto API and watchdog cron with structured logging when the key is absent
- document the `COINGECKO_API_KEY` deployment requirement for operations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc48ccb64c8322b58bdc3c769641d5