### PR TITLE
Support CoinGecko free mode without API key

### DIFF
--- a/__tests__/lib/crypto-core.test.js
+++ b/__tests__/lib/crypto-core.test.js
@@ -1,0 +1,108 @@
+const originalEnv = process.env;
+const realFetch = global.fetch;
+
+function createMockResponse(data) {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name) => (name && name.toLowerCase() === "content-type" ? "application/json" : null),
+    },
+    json: async () => data,
+  };
+}
+
+describe("CoinGecko mode handling", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    global.fetch = jest.fn(() => {
+      throw new Error("fetch not mocked");
+    });
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+  });
+
+  test("FREE mode bypasses API key validation", async () => {
+    process.env.COINGECKO_FREE = "true";
+    process.env.COINGECKO_API_KEY = "";
+
+    const payload = [
+      {
+        id: "bitcoin",
+        symbol: "btc",
+        name: "Bitcoin",
+        image: "btc.png",
+        current_price: 100,
+        market_cap: 200,
+        total_volume: 300,
+        price_change_percentage_1h_in_currency: 0.1,
+        price_change_percentage_24h_in_currency: 0.2,
+        price_change_percentage_7d_in_currency: 0.3,
+      },
+    ];
+
+    global.fetch.mockImplementation(async (url, opts = {}) => {
+      expect(opts.headers).toBeUndefined();
+      return createMockResponse(payload);
+    });
+
+    const { fetchCoinGeckoMarkets } = await import("../../lib/crypto-core.js");
+    const result = await fetchCoinGeckoMarkets("");
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        id: "bitcoin",
+        symbol: "BTC",
+        name: "Bitcoin",
+        image: "btc.png",
+        current_price: 100,
+        market_cap: 200,
+        total_volume: 300,
+        price_change_percentage_1h_in_currency: 0.1,
+        price_change_percentage_24h_in_currency: 0.2,
+        price_change_percentage_7d_in_currency: 0.3,
+      },
+    ]);
+  });
+
+  test("Pro mode enforces API key validation", async () => {
+    delete process.env.COINGECKO_FREE;
+    process.env.COINGECKO_API_KEY = "";
+
+    const { fetchCoinGeckoMarkets } = await import("../../lib/crypto-core.js");
+
+    await expect(fetchCoinGeckoMarkets("")).rejects.toMatchObject({
+      code: "coingecko_api_key_missing",
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("buildSignals uses FREE mode without an API key", async () => {
+    process.env.COINGECKO_FREE = "true";
+    process.env.COINGECKO_API_KEY = "";
+    process.env.CRYPTO_OKX_ENABLE = "0";
+    process.env.CRYPTO_BYBIT_ENABLE = "0";
+
+    global.fetch.mockImplementation(async (url, opts = {}) => {
+      expect(opts.headers).toBeUndefined();
+      return createMockResponse([]);
+    });
+
+    const cryptoCore = await import("../../lib/crypto-core.js");
+    const result = await cryptoCore.buildSignals();
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options?.headers).toBeUndefined();
+  });
+});

--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -88,7 +88,17 @@ export async function buildSignals(opts = {}) {
   const confidenceConfig = await getConfidenceConfig().catch(() => defaultConfidenceConfig());
 
   // ---- CG markets za shortlist ----
-  const cg = await fetchCoinGeckoMarkets(cgApiKey);
+  let cgMode = typeof opts.cgMode === "string" ? opts.cgMode.trim().toLowerCase() : "";
+  if (cgMode !== "free" && cgMode !== "pro") cgMode = "";
+  let cgFree = typeof opts.cgFree === "boolean" ? opts.cgFree : null;
+  if (cgFree == null) {
+    if (cgMode === "free") cgFree = true;
+    else if (cgMode === "pro") cgFree = false;
+    else cgFree = envBool("COINGECKO_FREE", false);
+  }
+  if (!cgMode) cgMode = cgFree ? "free" : "pro";
+
+  const cg = await fetchCoinGeckoMarkets(cgApiKey, { mode: cgMode, free: cgMode === "free" });
 
   // BTC gate (24h)
   const btc = cg.find((c) => (c.symbol || "").toUpperCase() === "BTC");
@@ -345,14 +355,28 @@ export async function reserveCoinGeckoQuota(now = Date.now()) {
   return { minute: minuteCount, day: dayCount };
 }
 
-export async function fetchCoinGeckoMarkets(apiKey = "") {
-  const validation = validateCoinGeckoApiKey(apiKey);
-  if (!validation.ok) {
-    const code = validation.code === "missing" ? "coingecko_api_key_missing" : "coingecko_api_key_invalid";
-    const err = new Error(code);
-    err.code = code;
-    err.details = { reason: validation.code };
-    throw err;
+export async function fetchCoinGeckoMarkets(apiKey = "", opts = {}) {
+  const modeHint = typeof opts.mode === "string" ? opts.mode.trim().toLowerCase() : "";
+  const explicitFree = typeof opts.free === "boolean" ? opts.free : null;
+  let isFree = explicitFree;
+  if (isFree == null) {
+    if (modeHint === "free") isFree = true;
+    else if (modeHint === "pro") isFree = false;
+    else isFree = envBool("COINGECKO_FREE", false);
+  }
+
+  let validation = null;
+  let headers = undefined;
+  if (!isFree) {
+    validation = validateCoinGeckoApiKey(apiKey);
+    if (!validation.ok) {
+      const code = validation.code === "missing" ? "coingecko_api_key_missing" : "coingecko_api_key_invalid";
+      const err = new Error(code);
+      err.code = code;
+      err.details = { reason: validation.code };
+      throw err;
+    }
+    headers = { "x-cg-demo-api-key": validation.key };
   }
 
   await reserveCoinGeckoQuota();
@@ -363,10 +387,10 @@ export async function fetchCoinGeckoMarkets(apiKey = "") {
   url.searchParams.set("page", "1");
   url.searchParams.set("sparkline", "false");
   url.searchParams.set("price_change_percentage", "1h,24h,7d");
-  const headers = { "x-cg-demo-api-key": validation.key };
+  const fetchOptions = headers ? { headers, cache: "no-store" } : { cache: "no-store" };
 
-  const r = await fetch(url, { headers, cache: "no-store" });
-  if (r.status === 401 || r.status === 403) {
+  const r = await fetch(url, fetchOptions);
+  if (!isFree && (r.status === 401 || r.status === 403)) {
     const err = new Error("coingecko_api_key_invalid");
     err.code = "coingecko_api_key_invalid";
     err.details = { status: r.status };


### PR DESCRIPTION
## Summary
- allow `buildSignals` to resolve CoinGecko mode from options or environment and forward it to the market fetcher
- update `fetchCoinGeckoMarkets` to bypass API key validation and headers when running in free mode while keeping pro validation in place
- add Jest coverage to confirm free-mode requests work without a key and that pro mode still enforces validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc72086f448322a2f21e2ba99ddc5a