### PR TITLE
Support CoinGecko free mode

### DIFF
--- a/__tests__/pages/api/crypto-handlers.test.js
+++ b/__tests__/pages/api/crypto-handlers.test.js
@@ -1,0 +1,113 @@
+const originalEnv = process.env;
+const realFetch = global.fetch;
+
+jest.mock("../../../lib/crypto-core", () => {
+  const actual = jest.requireActual("../../../lib/crypto-core");
+  return {
+    ...actual,
+    buildSignals: jest.fn(),
+  };
+});
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+describe("FREE mode API handlers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete global.__UPSTASH_FALLBACK_STORE__;
+    global.fetch = jest.fn(() => {
+      throw new Error("unexpected fetch call");
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = realFetch;
+  });
+
+  it("/api/crypto returns live data using FREE mode", async () => {
+    process.env.COINGECKO_FREE = "1";
+    process.env.COINGECKO_API_KEY = "";
+    process.env.CRYPTO_FALLBACK_STORE_TOKEN = "local";
+
+    const cryptoCore = require("../../../lib/crypto-core");
+    cryptoCore.buildSignals.mockResolvedValue([
+      {
+        symbol: "BTC",
+        signal: "LONG",
+        confidence_pct: 60,
+        entry: 100,
+        tp: 120,
+        sl: 90,
+        rr: 2,
+        expectedMove: 5,
+      },
+    ]);
+
+    const { default: handler } = require("../../../pages/api/crypto.js");
+
+    const req = { query: {}, headers: {} };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(cryptoCore.buildSignals).toHaveBeenCalledTimes(1);
+    expect(cryptoCore.buildSignals.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ cgFree: true })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload?.ok).toBe(true);
+    expect(res.jsonPayload?.source).toBe("live");
+  });
+
+  it("/api/cron/crypto-watchdog builds signals in FREE mode", async () => {
+    process.env.COINGECKO_FREE = "1";
+    process.env.COINGECKO_API_KEY = "";
+    process.env.CRYPTO_FALLBACK_STORE_TOKEN = "local";
+    process.env.CRON_KEY = "secret";
+
+    const cryptoCore = require("../../../lib/crypto-core");
+    cryptoCore.buildSignals.mockResolvedValue([
+      {
+        symbol: "BTC",
+        signal: "LONG",
+        confidence_pct: 60,
+        entry: 100,
+        tp: 120,
+        sl: 90,
+        rr: 2,
+        expectedMove: 5,
+      },
+    ]);
+
+    const { default: handler } = require("../../../pages/api/cron/crypto-watchdog.js");
+
+    const req = { query: { key: "secret" }, headers: {} };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(cryptoCore.buildSignals).toHaveBeenCalledTimes(1);
+    expect(cryptoCore.buildSignals.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ cgFree: true })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload?.ok).toBe(true);
+    expect(res.jsonPayload?.wrote).toBe(true);
+  });
+});

--- a/lib/crypto-core.js
+++ b/lib/crypto-core.js
@@ -100,7 +100,7 @@ export async function buildSignals(opts = {}) {
   }
   if (!cgMode) cgMode = cgFree ? "free" : "pro";
 
-  const cg = await fetchCoinGeckoMarkets(cgApiKey, { mode: cgMode, free: cgMode === "free" });
+  const cg = await fetchCoinGeckoMarkets(cgApiKey, { mode: cgMode, free: cgFree });
 
   // BTC gate (24h)
   const btc = cg.find((c) => (c.symbol || "").toUpperCase() === "BTC");
@@ -401,7 +401,9 @@ export async function fetchCoinGeckoMarkets(apiKey = "", opts = {}) {
     headers = { "x-cg-demo-api-key": validation.key };
   }
 
-  await reserveCoinGeckoQuota();
+  if (!isFree) {
+    await reserveCoinGeckoQuota();
+  }
   const url = new URL("https://api.coingecko.com/api/v3/coins/markets");
   url.searchParams.set("vs_currency", "usd");
   url.searchParams.set("order", "market_cap_desc");

--- a/pages/api/cron/crypto-watchdog.js
+++ b/pages/api/cron/crypto-watchdog.js
@@ -86,9 +86,11 @@ export default async function handler(req, res) {
 
     // 1) kandidati
     let itemsRaw;
+    const freeMode = envReport.free ?? parseBool(COINGECKO_FREE);
     try {
       itemsRaw = await buildSignals({
         cgApiKey: COINGECKO_API_KEY,
+        cgFree: freeMode,
         minVol: CFG.MIN_VOL,
         minMcap: CFG.MIN_MCAP,
         quorum: CFG.QUORUM,
@@ -212,16 +214,59 @@ function summarizeCoinGeckoEnv({
 } = {}) {
   const freeMode = parseBool(coingeckoFree ?? process.env.COINGECKO_FREE ?? "0");
   const fallbackActive = detectFallbackStore(fallbackStore);
-  const mode = freeMode ? "FREE" : "PAID";
 
-  const validation = validateCoinGeckoApiKey(apiKey);
+  const resolvedUrl = typeof upstashUrl === "string" ? upstashUrl : process.env.UPSTASH_REDIS_REST_URL;
+  const resolvedToken = typeof upstashToken === "string" ? upstashToken : process.env.UPSTASH_REDIS_REST_TOKEN;
+  const resolvedApiKey = typeof apiKey === "string" ? apiKey : process.env.COINGECKO_API_KEY;
 
+  const validation = validateCoinGeckoApiKey(resolvedApiKey);
+  const missing = [];
+
+  const keyStatus = (() => {
+    if (freeMode) {
+      return validation.ok ? "present" : "skipped";
+    }
+    if (validation.ok) return "present";
+    return validation.code || "missing";
+  })();
+
+  if (!freeMode && !validation.ok) {
+    missing.push("coingecko_api_key");
+  }
+
+  if (!fallbackActive) {
+    if (!hasValue(resolvedUrl)) missing.push("upstash_url");
+    if (!hasValue(resolvedToken)) missing.push("upstash_token");
+  }
 
   const log = {
-    mode,
+    mode: freeMode ? "FREE" : "PAID",
     store: fallbackActive ? "fallback" : "upstash",
     coingecko_api_key: keyStatus,
+  };
 
+  const summary = JSON.stringify(log);
+  const missingUnique = [...new Set(missing)];
+
+  return {
+    ok: missingUnique.length === 0,
+    summary,
+    missing: missingUnique,
+    free: freeMode,
+  };
+}
+
+function detectFallbackStore(value) {
+  if (typeof value === "boolean") return value;
+  if (value && typeof value === "object") {
+    if (value.available === true) return true;
+    if (typeof value.mode === "string" && value.mode.toLowerCase() === "fallback") return true;
+    if (typeof value.store === "string" && value.store.toLowerCase() === "fallback") return true;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === "1" || trimmed === "true" || trimmed === "fallback" || trimmed === "yes") return true;
+  }
 
   const tokenHints = [
     process.env.CRYPTO_FALLBACK_STORE_TOKEN,
@@ -229,7 +274,17 @@ function summarizeCoinGeckoEnv({
   ];
   if (tokenHints.some((raw) => typeof raw === "string" && raw.trim())) return true;
 
+  const urlHints = [
+    process.env.CRYPTO_FALLBACK_STORE_URL,
+    process.env.CRYPTO_STORE_FALLBACK_URL,
+  ];
+  if (urlHints.some((raw) => typeof raw === "string" && raw.trim())) return true;
+
   return false;
+}
+
+function hasValue(raw) {
+  return typeof raw === "string" && raw.trim().length > 0;
 }
 
 function isCoinGeckoQuotaError(err) {


### PR DESCRIPTION
## Summary
- propagate the CoinGecko FREE-mode flag from both crypto API handlers into `buildSignals` and enrich the environment summary helpers to report the mode explicitly
- have `fetchCoinGeckoMarkets` honour the FREE flag by skipping API-key validation, quota reservation, and header injection when credentials are intentionally absent
- add regression tests that cover the FREE-mode code paths for the crypto APIs and existing CoinGecko free-mode logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7ace492c832282b84e9d9f1e50a0