### PR TITLE
Ensure KV helpers stringify objects

### DIFF
--- a/pages/api/crypto-history-day.js
+++ b/pages/api/crypto-history-day.js
@@ -15,9 +15,15 @@ async function kvGETraw(key) {
     try {
       const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`, { headers:{ Authorization:`Bearer ${b.tok}` }, cache:"no-store" });
       const j = await r.json().catch(()=>null);
-      const raw = typeof j?.result === "string" ? j.result : null;
+      const payload = j?.result ?? j?.value;
+      let raw = null;
+      if (typeof payload === "string") {
+        raw = payload;
+      } else if (payload !== undefined) {
+        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
+      }
       if (!r.ok) continue;
-      return raw;
+      return typeof raw === "string" ? raw : null;
     } catch {}
   }
   return null;

--- a/pages/api/football.js
+++ b/pages/api/football.js
@@ -12,7 +12,12 @@ async function kvGetRaw(key) {
     const r = await fetch(`${KV_URL.replace(/\/+$/,"")}/get/${encodeURIComponent(key)}`, { headers:{ Authorization:`Bearer ${KV_TOKEN}` }, cache:"no-store" });
     if (!r.ok) return null;
     const j = await r.json().catch(()=>null);
-    return typeof j?.result === "string" ? j.result : null;
+    const payload = j?.result ?? j?.value;
+    if (typeof payload === "string") return payload;
+    if (payload !== undefined) {
+      try { return JSON.stringify(payload ?? null); } catch { return null; }
+    }
+    return null;
   } catch { return null; }
 }
 const J = s => { try { return JSON.parse(s); } catch { return null; } };

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -21,8 +21,14 @@ async function kvGETraw(key, trace) {
         cache: "no-store",
       });
       const j = await r.json().catch(() => null);
-      const raw = typeof j?.result === "string" ? j.result : null;
-      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: !!raw });
+      const payload = j?.result ?? j?.value;
+      let raw = null;
+      if (typeof payload === "string") {
+        raw = payload;
+      } else if (payload !== undefined) {
+        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
+      }
+      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: typeof raw === "string" });
       if (!r.ok) continue;
       return { raw, flavor: b.flavor };
     } catch (e) {

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -20,8 +20,14 @@ async function kvGETraw(key, trace) {
         cache: "no-store",
       });
       const j = await r.json().catch(() => null);
-      const raw = typeof j?.result === "string" ? j.result : null;
-      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: !!raw });
+      const payload = j?.result ?? j?.value;
+      let raw = null;
+      if (typeof payload === "string") {
+        raw = payload;
+      } else if (payload !== undefined) {
+        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
+      }
+      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: typeof raw === "string" });
       if (!r.ok) continue;
       return { raw, flavor: b.flavor };
     } catch (e) {

--- a/pages/api/insights-build.js
+++ b/pages/api/insights-build.js
@@ -22,8 +22,14 @@ async function kvGETraw(key, trace) {
     try {
       const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`,{ headers:{ Authorization:`Bearer ${b.tok}` }, cache:"no-store" });
       const j = await r.json().catch(()=>null);
-      const raw = typeof j?.result === "string" ? j.result : null;
-      trace && trace.push({ get:key, ok:r.ok, flavor:b.flavor, hit:!!raw });
+      const payload = j?.result ?? j?.value;
+      let raw = null;
+      if (typeof payload === "string") {
+        raw = payload;
+      } else if (payload !== undefined) {
+        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
+      }
+      trace && trace.push({ get:key, ok:r.ok, flavor:b.flavor, hit: typeof raw === "string" });
       if (!r.ok) continue;
       return { raw, flavor:b.flavor };
     } catch (e) { trace && trace.push({ get:key, ok:false, err:String(e?.message||e) }); }


### PR DESCRIPTION
## Summary
- update KV fetch helpers across insights/history/crypto/football APIs to read either result or value and stringify non-string payloads
- keep tracing logic while marking hits based on the coerced JSON string values
- ensure downstream parsing continues to receive JSON strings from Redis-backed storage

## Testing
- npm run dev (manually verified API route responses)
- curl http://localhost:3000/api/insights-build?slot=am
- curl http://localhost:3000/api/football
- curl http://localhost:3000/api/history

------
https://chatgpt.com/codex/tasks/task_e_68cd298a6a008322a8c5c99c65318c20