### PR TITLE
Add debug metadata controls for KV-backed APIs

### DIFF
--- a/__tests__/pages/api/history-normalization.test.js
+++ b/__tests__/pages/api/history-normalization.test.js
@@ -78,7 +78,7 @@ describe("API history market normalization", () => {
 
     const { default: handler } = require("../../../pages/api/history");
 
-    const req = { query: { ymd: "2024-05-01" } };
+    const req = { query: { ymd: "2024-05-01", debug: "1" } };
     const res = createMockRes();
 
     await handler(req, res);
@@ -99,7 +99,7 @@ describe("API history market normalization", () => {
 
     const { default: handler } = require("../../../pages/api/history-roi");
 
-    const req = { query: { ymd: "2024-05-01" } };
+    const req = { query: { ymd: "2024-05-01", debug: "1" } };
     const res = createMockRes();
 
     await handler(req, res);


### PR DESCRIPTION
## Summary
- capture KV fetch metadata including source flavor and whether the payload was originally an object across history, ROI, insights-build, crypto history day, and football endpoints
- only emit debug payloads when `debug=1` is provided and expose new `sourceFlavor` and `kvObject` fields when debug data is returned
- update associated tests to request debug output after gating the response

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2dd35dc48322977091dc77825e71