### PR TITLE
Add KV parsing helpers and tests for history API

### DIFF
--- a/__tests__/lib/kv-read.test.ts
+++ b/__tests__/lib/kv-read.test.ts
@@ -1,0 +1,45 @@
+import { arrFromAny, toJson } from "../../lib/kv-read";
+
+describe("toJson", () => {
+  it("parses JSON strings", () => {
+    const payload = toJson('{"items":[{"id":1}]}');
+    expect(payload).toEqual({ items: [{ id: 1 }] });
+  });
+
+  it("returns objects unchanged", () => {
+    const obj = { items: [{ id: 2 }] };
+    expect(toJson(obj)).toBe(obj);
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(toJson("not-json")).toBeNull();
+  });
+});
+
+describe("arrFromAny", () => {
+  it("returns arrays unchanged", () => {
+    const arr = [{ id: "direct" }];
+    expect(arrFromAny(arr)).toBe(arr);
+  });
+
+  it("extracts items from nested objects", () => {
+    const base = [{ id: "nested" }];
+    expect(arrFromAny({ items: base })).toBe(base);
+  });
+
+  it("reads history lists", () => {
+    const base = [{ id: "history" }];
+    expect(arrFromAny({ history: base })).toBe(base);
+  });
+
+  it("reads list fallback", () => {
+    const base = [{ id: "list" }];
+    expect(arrFromAny({ list: base })).toBe(base);
+  });
+
+  it("returns an empty array for malformed input", () => {
+    expect(arrFromAny({ other: [] })).toEqual([]);
+    expect(arrFromAny(null)).toEqual([]);
+    expect(arrFromAny(undefined)).toEqual([]);
+  });
+});

--- a/__tests__/pages/api/history-kv.test.ts
+++ b/__tests__/pages/api/history-kv.test.ts
@@ -1,0 +1,109 @@
+const originalEnv = process.env;
+const realFetch = global.fetch;
+
+type MockResponse = {
+  statusCode: number;
+  jsonPayload: any;
+  status(code: number): MockResponse;
+  json(payload: any): MockResponse;
+};
+
+function createMockRes(): MockResponse {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+describe("history API KV result normalization", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    process.env.HISTORY_ALLOWED_MARKETS = "h2h";
+    process.env.KV_REST_API_URL = "https://kv.example";
+    process.env.KV_REST_API_TOKEN = "kv-token";
+    global.fetch = jest.fn(() => {
+      throw new Error("fetch not mocked");
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("handles stringified KV history payloads", async () => {
+    const items = [
+      {
+        fixture_id: "fx-1",
+        market_key: "h2h",
+        pick: "home",
+        result: "win",
+      },
+    ];
+
+    const fetchMock = global.fetch as unknown as jest.Mock;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: JSON.stringify({ items }) }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+
+    const { default: handler } = await import("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-05-01" } };
+    const res = createMockRes();
+
+    await handler(req, res as any);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.count).toBeGreaterThan(0);
+    expect(res.jsonPayload.history).toHaveLength(res.jsonPayload.count);
+  });
+
+  it("handles object KV history payloads", async () => {
+    const items = [
+      {
+        fixture_id: "fx-2",
+        market_key: "h2h",
+        pick: "home",
+        result: "win",
+      },
+    ];
+
+    const fetchMock = global.fetch as unknown as jest.Mock;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { items } }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+
+    const { default: handler } = await import("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-05-02" } };
+    const res = createMockRes();
+
+    await handler(req, res as any);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.count).toBeGreaterThan(0);
+    expect(res.jsonPayload.history).toHaveLength(res.jsonPayload.count);
+  });
+});

--- a/lib/kv-read.js
+++ b/lib/kv-read.js
@@ -1,0 +1,35 @@
+// lib/kv-read.js
+// Helpers for reading KV payloads where values may be raw strings or JSON objects.
+
+export function toJson(value) {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    const text = String(value);
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === "object") {
+    return value;
+  }
+  try {
+    return JSON.parse(String(value));
+  } catch {
+    return null;
+  }
+}
+
+export function arrFromAny(input) {
+  if (Array.isArray(input)) return input;
+  if (input && typeof input === "object") {
+    if (Array.isArray(input.items)) return input.items;
+    if (Array.isArray(input.history)) return input.history;
+    if (Array.isArray(input.list)) return input.list;
+  }
+  return [];
+}
+
+export default { toJson, arrFromAny };

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -1,5 +1,6 @@
 // File: pages/api/history-roi.js
 import { computeROI } from "../../lib/history-utils";
+import { arrFromAny, toJson } from "../../lib/kv-read";
 import { normalizeMarketKey } from "./history";
 
 export const config = { api: { bodyParser: false } };
@@ -39,7 +40,6 @@ async function kvGETraw(key, trace) {
 }
 
 /* ---------- helpers ---------- */
-const J = (s) => { try { return JSON.parse(String(s || "")); } catch { return null; } };
 const isValidYmd = (s) => /^\d{4}-\d{2}-\d{2}$/.test(String(s || ""));
 
 const DEFAULT_MARKET_KEY = "h2h";
@@ -54,13 +54,6 @@ function parseAllowedMarkets(envVal) {
   return new Set(list.length ? list : [fallback]);
 }
 const allowSet = parseAllowedMarkets(process.env.HISTORY_ALLOWED_MARKETS);
-
-const arrFromAny = (x) =>
-  Array.isArray(x) ? x
-  : (x && typeof x === "object" && Array.isArray(x.items)) ? x.items
-  : (x && typeof x === "object" && Array.isArray(x.history)) ? x.history
-  : (x && typeof x === "object" && Array.isArray(x.list)) ? x.list
-  : [];
 
 function dedupKey(e, normalizedMarketKey) {
   const m = normalizedMarketKey ?? normalizeMarketKey(e?.market_key);
@@ -83,12 +76,12 @@ async function loadDay(ymd, trace) {
   const histKey = `hist:${ymd}`;
   const { raw: rawHist } = await kvGETraw(histKey, trace);
 
-  let items = filterAllowed(arrFromAny(J(rawHist)));
+  let items = filterAllowed(arrFromAny(toJson(rawHist)));
 
   const combKey = `vb:day:${ymd}:combined`;
   const { raw: rawComb } = await kvGETraw(combKey, trace);
   if (!items.length && rawComb) {
-    items = filterAllowed(arrFromAny(J(rawComb)));
+    items = filterAllowed(arrFromAny(toJson(rawComb)));
   }
   return items;
 }


### PR DESCRIPTION
## Summary
- add a shared `lib/kv-read` helper that converts KV payloads into JSON arrays
- update the history endpoints to consume the helper utilities when parsing Upstash responses
- add tests covering the helper behaviour and history API responses for string and object KV payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2dd40e648322b4328059a1b55b36