### PR TITLE
Add history smoke test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+## History smoke test script
+
+`scripts/smoke-history.mjs` performs a lightweight check against `/api/history` for today's date. The run fails when the endpoint responds with a zero count so CI jobs can catch stale data early.
+
+### Environment variables
+
+- `BASE`: Base URL for the deployment under test. Defaults to `http://localhost:3000` when undefined.
+
+### Usage
+
+```bash
+node scripts/smoke-history.mjs
+BASE="https://predictscores.example.com" node scripts/smoke-history.mjs
+```
+
 ## Snapshots guard tuning
 
 The scheduled "Snapshots (AM/PM/LATE)" workflow uses a guard window to avoid

--- a/scripts/smoke-history.mjs
+++ b/scripts/smoke-history.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const DEFAULT_BASE = "http://localhost:3000";
+const baseEnv = (process.env.BASE || "").trim();
+const base = (baseEnv || DEFAULT_BASE).replace(/\/+$/, "");
+
+const today = new Date();
+const todayUtc = new Date(Date.UTC(
+  today.getUTCFullYear(),
+  today.getUTCMonth(),
+  today.getUTCDate(),
+));
+const ymd = todayUtc.toISOString().slice(0, 10);
+
+const endpoint = `${base}/api/history?ymd=${encodeURIComponent(ymd)}`;
+
+const fail = (message) => {
+  console.error(`[smoke-history] ${message}`);
+  process.exit(1);
+};
+
+try {
+  const response = await fetch(endpoint, {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    fail(`Request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json().catch(() => null);
+
+  if (!payload || typeof payload.count !== "number") {
+    fail("Response missing numeric 'count'.");
+  }
+
+  if (payload.count === 0) {
+    fail("History count is zero.");
+  }
+
+  console.log(`[smoke-history] count=${payload.count}`);
+} catch (error) {
+  fail(error?.message || String(error));
+}


### PR DESCRIPTION
## Summary
- add a smoke test script that fetches `/api/history` for today and fails when the count is zero
- document the `BASE` environment variable and script usage in the README

## Testing
- not run (script only)


------
https://chatgpt.com/codex/tasks/task_e_68cd2dd581448322b3db88db88e79940