### PR TITLE
Add smoke CI workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,31 @@
+name: Smoke
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18.17
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.17.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Smoke history endpoint
+        env:
+          BASE: https://predictscores-mock.vercel.app
+        run: node scripts/smoke-history.mjs


### PR DESCRIPTION
## Summary
- add a smoke GitHub Actions workflow running on pull requests and main pushes
- install Node 18.17 dependencies, run unit tests, and execute the smoke history script against the mock base URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2dd99f8c8322921ee3577761f607