### PR TITLE
Align KV parsing helpers and add smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,33 @@
+name: Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - name: Start app
+        run: PORT=3000 npm start &
+      - name: Wait for history endpoint
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3000/api/history > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server did not become ready" >&2
+          exit 1
+      - name: Smoke history
+        run: BASE=http://localhost:3000 node scripts/smoke-history.mjs

--- a/__tests__/api-history-kv-modes.test.js
+++ b/__tests__/api-history-kv-modes.test.js
@@ -1,0 +1,71 @@
+import handler from "../pages/api/history";
+
+const originalFetch = global.fetch;
+
+function createRes() {
+  const res = {};
+  res.status = jest.fn().mockImplementation(() => res);
+  res.json = jest.fn();
+  return res;
+}
+
+function setKvEnv() {
+  process.env.KV_REST_API_URL = "https://example.com";
+  process.env.KV_REST_API_TOKEN = "token";
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+}
+
+function mockFetchSequence(envelopes) {
+  const queue = envelopes.slice();
+  global.fetch = jest.fn().mockImplementation(() => {
+    const next = queue.length ? queue.shift() : { result: JSON.stringify({ items: [] }) };
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(next),
+    });
+  });
+}
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  delete process.env.KV_REST_API_URL;
+  delete process.env.KV_REST_API_TOKEN;
+  jest.resetAllMocks();
+});
+
+test("history accepts stringified KV payloads", async () => {
+  setKvEnv();
+  mockFetchSequence([
+    { result: JSON.stringify({ items: [{ id: 1, market_key: "h2h", pick: "home" }] }) },
+    { result: JSON.stringify({ items: [] }) },
+  ]);
+
+  const req = { query: { ymd: "2024-01-01" } };
+  const res = createRes();
+
+  await handler(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(200);
+  const payload = res.json.mock.calls[0][0];
+  expect(payload.ok).toBe(true);
+  expect(payload.count).toBeGreaterThan(0);
+});
+
+test("history accepts object KV payloads", async () => {
+  setKvEnv();
+  mockFetchSequence([
+    { result: { items: [{ id: 2, market_key: "h2h", pick: "away" }] } },
+    { result: { items: [] } },
+  ]);
+
+  const req = { query: { ymd: "2024-01-02" } };
+  const res = createRes();
+
+  await handler(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(200);
+  const payload = res.json.mock.calls[0][0];
+  expect(payload.ok).toBe(true);
+  expect(payload.count).toBeGreaterThan(0);
+});

--- a/__tests__/kv-read.test.js
+++ b/__tests__/kv-read.test.js
@@ -1,0 +1,35 @@
+import { arrFromAny, toJson } from "../lib/kv-read";
+
+describe("toJson", () => {
+  it("returns objects unchanged", () => {
+    const obj = { a: 1 };
+    expect(toJson(obj)).toBe(obj);
+  });
+
+  it("parses JSON strings", () => {
+    expect(toJson('{"x":42}')).toEqual({ x: 42 });
+  });
+
+  it("returns null for invalid inputs", () => {
+    expect(toJson("nope")).toBeNull();
+    expect(toJson(null)).toBeNull();
+  });
+});
+
+describe("arrFromAny", () => {
+  it("returns arrays as-is", () => {
+    const arr = [1, 2, 3];
+    expect(arrFromAny(arr)).toBe(arr);
+  });
+
+  it("extracts items-like properties", () => {
+    expect(arrFromAny({ items: [1] })).toEqual([1]);
+    expect(arrFromAny({ history: [2] })).toEqual([2]);
+    expect(arrFromAny({ list: [3] })).toEqual([3]);
+  });
+
+  it("falls back to empty array", () => {
+    expect(arrFromAny({ foo: [1] })).toEqual([]);
+    expect(arrFromAny(undefined)).toEqual([]);
+  });
+});

--- a/__tests__/lib/kv-read.test.js
+++ b/__tests__/lib/kv-read.test.js
@@ -1,73 +1,37 @@
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 describe("toJson", () => {
-  test("returns null metadata for null inputs", () => {
-    const result = toJson(null);
-
-    expect(result.value).toBeNull();
-    expect(result.meta.sourceType).toBe("null");
-    expect(result.meta.valueType).toBe("null");
-    expect(result.meta.parsed).toBe(false);
-    expect(result.meta.empty).toBe(true);
+  test("returns null for null inputs", () => {
+    expect(toJson(null)).toBeNull();
+    expect(toJson(undefined)).toBeNull();
   });
 
-  test("returns plain objects as-is without parsing", () => {
+  test("returns objects unchanged", () => {
     const payload = { foo: "bar", nested: { value: 42 } };
-    const result = toJson(payload);
-
-    expect(result.value).toBe(payload);
-    expect(result.meta.sourceIsObject).toBe(true);
-    expect(result.meta.valueIsObject).toBe(true);
-    expect(result.meta.parsed).toBe(false);
-    expect(result.meta.empty).toBe(false);
+    expect(toJson(payload)).toBe(payload);
   });
 
-  test("gracefully handles invalid JSON strings", () => {
-    const result = toJson("{not: 'valid'}");
-
-    expect(result.value).toBeNull();
-    expect(result.meta.sourceIsString).toBe(true);
-    expect(result.meta.parsed).toBe(false);
-    expect(result.meta.error).toBe("invalid_json");
+  test("parses JSON strings and ignores invalid ones", () => {
+    expect(toJson('{"foo":1}')).toEqual({ foo: 1 });
+    expect(toJson("{not:'valid'}")).toBeNull();
   });
 });
 
 describe("arrFromAny", () => {
-  test("returns direct arrays with self source metadata", () => {
-    const input = [1, 2, 3];
-    const result = arrFromAny(input);
-
-    expect(result.array).toBe(input);
-    expect(result.meta.arraySource).toBe("self");
-    expect(result.meta.length).toBe(3);
-    expect(result.meta.valueIsArray).toBe(true);
+  test("returns the input array when given an array", () => {
+    const arr = [1, 2, 3];
+    expect(arrFromAny(arr)).toBe(arr);
   });
 
-  test("uses items arrays when available", () => {
-    const input = { items: [{ id: 1 }] };
-    const result = arrFromAny(input);
-
-    expect(result.array).toEqual(input.items);
-    expect(result.meta.arraySource).toBe("items");
-    expect(result.meta.length).toBe(1);
-    expect(result.meta.valueIsObject).toBe(false);
+  test("pulls from items/history/list arrays", () => {
+    expect(arrFromAny({ items: [{ id: 1 }] })).toEqual([{ id: 1 }]);
+    expect(arrFromAny({ history: [{ id: 2 }] })).toEqual([{ id: 2 }]);
+    expect(arrFromAny({ list: [{ id: 3 }] })).toEqual([{ id: 3 }]);
   });
 
-  test("falls back to history arrays when items is not an array", () => {
-    const input = { items: null, history: [{ id: 2 }] };
-    const result = arrFromAny(input);
-
-    expect(result.array).toEqual(input.history);
-    expect(result.meta.arraySource).toBe("history");
-    expect(result.meta.length).toBe(1);
-  });
-
-  test("falls back to list arrays when other keys are unavailable", () => {
-    const input = { items: "x", history: {}, list: [{ id: 3 }] };
-    const result = arrFromAny(input);
-
-    expect(result.array).toEqual(input.list);
-    expect(result.meta.arraySource).toBe("list");
-    expect(result.meta.length).toBe(1);
+  test("falls back to empty array when nothing matches", () => {
+    expect(arrFromAny({})).toEqual([]);
+    expect(arrFromAny({ items: null, history: null })).toEqual([]);
+    expect(arrFromAny("oops")).toEqual([]);
   });
 });

--- a/__tests__/pages/api/history-normalization.test.js
+++ b/__tests__/pages/api/history-normalization.test.js
@@ -27,8 +27,8 @@ const sampleHistoryPayload = {
 const realFetch = global.fetch;
 
 const kvResponseModes = [
-  ["string payloads", (payload) => ({ result: JSON.stringify(payload) })],
-  ["object payloads", (payload) => ({ result: payload })],
+  ["string payloads", (payload) => ({ result: JSON.stringify(payload) }), false],
+  ["object payloads", (payload) => ({ result: payload }), true],
 ];
 
 function createMockRes() {
@@ -46,7 +46,7 @@ function createMockRes() {
   };
 }
 
-describe.each(kvResponseModes)("API history market normalization (%s)", (modeLabel, makeEnvelope) => {
+describe.each(kvResponseModes)("API history market normalization (%s)", (modeLabel, makeEnvelope, expectKvObject) => {
   function mockKvResponses(fetchMock, payload) {
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -94,7 +94,10 @@ describe.each(kvResponseModes)("API history market normalization (%s)", (modeLab
     expect(res.jsonPayload.history.map((e) => e.market_key)).toEqual(
       expect.arrayContaining(["H2H!!! ", "Total-Goals??"])
     );
-    expect(res.jsonPayload.debug.allowed).toEqual(["h2h", "total-goals"]);
+    expect(res.jsonPayload.debug).toEqual({
+      sourceFlavor: "vercel-kv",
+      kvObject: expectKvObject,
+    });
   });
 
   it("includes normalized market keys in ROI calculations", async () => {
@@ -113,6 +116,9 @@ describe.each(kvResponseModes)("API history market normalization (%s)", (modeLab
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload.count).toBe(2);
     expect(res.jsonPayload.roi).toMatchObject({ played: 2, wins: 1 });
-    expect(res.jsonPayload.debug.allowed).toEqual(["h2h", "total-goals"]);
+    expect(res.jsonPayload.debug).toEqual({
+      sourceFlavor: "vercel-kv",
+      kvObject: expectKvObject,
+    });
   });
 });

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,46 +1,10 @@
 # Developer notes
 
-## History KV smoke test
-
-`node scripts/smoke-history.mjs` performs a quick smoke test against the value
-bets history snapshots stored in KV. It fetches the latest days, verifies that
-at least one backend responds, and calculates the return-on-investment summary
-using the same normalization logic as the `/api/history` and `/api/history-roi`
-endpoints.
-
-### Environment
-
-Export the credentials for whichever KV backends you want the script to hit:
-
-- `KV_REST_API_URL` and `KV_REST_API_TOKEN` for Vercel KV.
-- `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` for Upstash Redis
-  (optional fallback; leave blank to skip it).
-- `HISTORY_ALLOWED_MARKETS` (optional) to mirror production market filters when
-  computing ROI.
-
-Running under Node.js 18+ matches the production runtime. You can place the
-variables in `.env.local` and source it before running the script if you prefer.
-
-### Running the smoke test
+## Smoke check
 
 ```
-node scripts/smoke-history.mjs
+npm run build && npm start
+BASE=http://localhost:3000 node scripts/smoke-history.mjs
 ```
 
-The script prints the backend it is talking to, the keys it probes for each
-recent day, and a compact ROI summary. Numbers will vary with live data, but a
-healthy run looks similar to the snippet below:
-
-```
-$ node scripts/smoke-history.mjs
-history smoke (last 14 days)
-vercel-kv     hist:2024-05-31 -> items=24 (hist ✅, combined ❌)
-vercel-kv     hist:2024-05-30 -> items=17 (hist ✅, combined ✅)
-...
-ROI: played=41 wins=22 profit=5.6 roi=0.136 winrate=0.54 avg_odds=1.92
-Done in 1.2s.
-```
-
-If a backend is unreachable or credentials are missing the script will log a
-non-zero status for that provider so you can spot configuration issues before
-running scheduled jobs.
+Use `DEBUG=1` to append `&debug=1`.

--- a/lib/kv-read.js
+++ b/lib/kv-read.js
@@ -1,41 +1,15 @@
 export function toJson(val) {
-  if (typeof val === "string") {
-    const trimmed = val.trim();
-    if (!trimmed) return null;
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      return null;
-    }
-  }
-
-  if (val && typeof val === "object") {
-    return val;
-  }
-
-  if (typeof val === "number" || typeof val === "boolean") {
-    return null;
-  }
-
+  if (val == null) return null;
+  if (typeof val === "object") return val; // Upstash/Vercel KV may return objects directly
+  if (typeof val === "string") { try { return JSON.parse(val); } catch { return null; } }
   return null;
 }
-
-export function arrFromAny(input) {
-  if (Array.isArray(input)) {
-    return input;
+export function arrFromAny(x) {
+  if (Array.isArray(x)) return x;
+  if (x && typeof x === "object") {
+    if (Array.isArray(x.items)) return x.items;
+    if (Array.isArray(x.history)) return x.history;
+    if (Array.isArray(x.list)) return x.list;
   }
-
-  if (input && typeof input === "object") {
-    if (Array.isArray(input.items)) {
-      return input.items;
-    }
-    if (Array.isArray(input.history)) {
-      return input.history;
-    }
-    if (Array.isArray(input.list)) {
-      return input.list;
-    }
-  }
-
   return [];
 }

--- a/pages/api/football.js
+++ b/pages/api/football.js
@@ -1,5 +1,4 @@
 // pages/api/football.js
-import { jsonMeta, arrayMeta } from "../../lib/kv-meta";
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 export const config = { api: { bodyParser: false } };
@@ -7,36 +6,58 @@ export const config = { api: { bodyParser: false } };
 const TZ = process.env.TZ_DISPLAY || "Europe/Belgrade";
 
 /* KV */
-const KV_URL   = process.env.KV_REST_API_URL;
-const KV_TOKEN = process.env.KV_REST_API_TOKEN;
-async function kvGetRaw(key) {
-  if (!KV_URL || !KV_TOKEN) return null;
-  try {
-    const r = await fetch(`${KV_URL.replace(/\/+$/,"")}/get/${encodeURIComponent(key)}`, { headers:{ Authorization:`Bearer ${KV_TOKEN}` }, cache:"no-store" });
-    if (!r.ok) return null;
-    const j = await r.json().catch(()=>null);
-    const payload = j?.result ?? j?.value;
-    if (typeof payload === "string") return payload;
-    if (payload !== undefined) {
-      try { return JSON.stringify(payload ?? null); } catch { return null; }
-    }
-    return null;
-  } catch { return null; }
+function kvBackends() {
+  const out = [];
+  const aU = process.env.KV_REST_API_URL, aT = process.env.KV_REST_API_TOKEN;
+  const bU = process.env.UPSTASH_REDIS_REST_URL, bT = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (aU && aT) out.push({ flavor: "vercel-kv", url: aU.replace(/\/+$/, ""), tok: aT });
+  if (bU && bT) out.push({ flavor: "upstash-redis", url: bU.replace(/\/+$/, ""), tok: bT });
+  return out;
 }
+async function kvGetItems(key) {
+  for (const b of kvBackends()) {
+    try {
+      const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`, {
+        headers: { Authorization: `Bearer ${b.tok}` },
+        cache: "no-store",
+      });
+      const j = await r.json().catch(() => null);
+      const res = j && ("result" in j ? j.result : j);
+      const obj = toJson(res);
+      const items = arrFromAny(obj);
+      if (!r.ok) continue;
+      return { items, obj, flavor: b.flavor, kvResult: res };
+    } catch {}
+  }
+  return { items: [], obj: null, flavor: null, kvResult: null };
+}
+
 /* Helpers */
 const ymdInTZ = (d, tz) => new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
-const hourInTZ = (d, tz) => Number(new Intl.DateTimeFormat("en-GB", { timeZone: tz, hour12: false, hour:"2-digit" }).format(d));
+const hourInTZ = (d, tz) => Number(new Intl.DateTimeFormat("en-GB", { timeZone: tz, hour12: false, hour: "2-digit" }).format(d));
 const now = () => new Date();
-const isUEFA = (name="") => /UEFA|Champions\s*League|Europa|Conference/i.test(name);
-const confidence = it => Number.isFinite(it?.confidence_pct) ? it.confidence_pct : (Number(it?.confidence)||0);
+const isUEFA = (name = "") => /UEFA|Champions\s*League|Europa|Conference/i.test(name);
+const confidence = (it) => (Number.isFinite(it?.confidence_pct) ? it.confidence_pct : Number(it?.confidence) || 0);
 
-/* Caps / tier env (mogu se podešavati ENV-om, postoje safe default-i) */
-function intEnv(v, d, lo=0, hi=999) { const n = Number(v); return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : d; }
-function numEnv(v, d) { const n = Number(v); return Number.isFinite(n) ? n : d; }
-function safeRegex(s) { try { return new RegExp(s, "i"); } catch { return /$a^/; } }
+/* Caps / tier env */
+function intEnv(v, d, lo = 0, hi = 999) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : d;
+}
+function numEnv(v, d) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+function safeRegex(s) {
+  try {
+    return new RegExp(s, "i");
+  } catch {
+    return /$a^/;
+  }
+}
 
-const TIER1_RE  = safeRegex(process.env.TIER1_RE || "(Premier League|La Liga|Serie A|Bundesliga|Ligue 1|Champions League|UEFA\\s*Champ)");
-const TIER2_RE  = safeRegex(process.env.TIER2_RE || "(Championship|Eredivisie|Primeira|Liga Portugal|Super Lig|Pro League|Bundesliga 2|Serie B|LaLiga 2|Ligue 2|Eerste Divisie)");
+const TIER1_RE = safeRegex(process.env.TIER1_RE || "(Premier League|La Liga|Serie A|Bundesliga|Ligue 1|Champions League|UEFA\\s*Champ)");
+const TIER2_RE = safeRegex(process.env.TIER2_RE || "(Championship|Eredivisie|Primeira|Liga Portugal|Super Lig|Pro League|Bundesliga 2|Serie B|LaLiga 2|Ligue 2|Eerste Divisie)");
 const TIER1_CAP = intEnv(process.env.TIER1_CAP, 7, 0, 15);
 const TIER2_CAP = intEnv(process.env.TIER2_CAP, 5, 0, 15);
 const TIER3_CAP = intEnv(process.env.TIER3_CAP, 3, 0, 15);
@@ -45,7 +66,7 @@ const MAX_PER_LEAGUE = intEnv(process.env.VB_MAX_PER_LEAGUE, 2, 1, 10);
 const UEFA_DAILY_CAP = intEnv(process.env.UEFA_DAILY_CAP, 6, 1, 20);
 
 /* Tier scoring */
-function tierScore(leagueName="") {
+function tierScore(leagueName = "") {
   if (TIER1_RE.test(leagueName)) return 3;
   if (TIER2_RE.test(leagueName)) return 2;
   return 1;
@@ -56,77 +77,52 @@ export default async function handler(req, res) {
     const d = now();
     const ymd = ymdInTZ(d, TZ);
     const h = hourInTZ(d, TZ);
-    const slot = h<10 ? "late" : h<15 ? "am" : "pm";
+    const slot = h < 10 ? "late" : h < 15 ? "am" : "pm";
 
     const wantDebug = String(req.query?.debug || "") === "1";
-    const readMeta = wantDebug ? [] : null;
 
-    // Try locked full for slot
     const fullKey = `vbl_full:${ymd}:${slot}`;
-    const fullRaw = await kvGetRaw(fullKey);
-    const fullValue = toJson(fullRaw);
-    const fullArr = arrFromAny(fullValue);
-    if (wantDebug) {
-      const fullJsonMeta = jsonMeta(fullRaw, fullValue);
-      const fullArrayMeta = arrayMeta(fullValue, fullArr, fullJsonMeta);
-      readMeta.push({ key: fullKey, json: fullJsonMeta, array: fullArrayMeta });
-    }
-    let items = fullArr;
+    const full = await kvGetItems(fullKey);
 
-    // Fallback: uzmi vb:day:<ymd>:<slot> / union / last (bez poziva frontu)
+    let items = full.items;
+    let chosenFlavor = items.length ? full.flavor : null;
+    let chosenResult = items.length ? full.kvResult : undefined;
+    let debugFlavor = full.flavor;
+    let debugResult = full.kvResult;
+
     if (!items.length) {
-      const keySlot = `vb:day:${ymd}:${slot}`;
-      const fall1Raw = await kvGetRaw(keySlot);
-      const fall1Value = toJson(fall1Raw);
-      const fall1Arr = arrFromAny(fall1Value);
-      if (wantDebug) {
-        const fall1JsonMeta = jsonMeta(fall1Raw, fall1Value);
-        const fall1ArrayMeta = arrayMeta(fall1Value, fall1Arr, fall1JsonMeta);
-        readMeta.push({ key: keySlot, json: fall1JsonMeta, array: fall1ArrayMeta });
+      const fallbacks = [`vb:day:${ymd}:${slot}`, `vb:day:${ymd}:union`, `vb:day:${ymd}:last`];
+      for (const key of fallbacks) {
+        const attempt = await kvGetItems(key);
+        if (!debugFlavor && attempt.flavor) debugFlavor = attempt.flavor;
+        if (debugResult === undefined && attempt.kvResult !== undefined) debugResult = attempt.kvResult;
+        if (attempt.items.length) {
+          items = attempt.items;
+          chosenFlavor = attempt.flavor;
+          chosenResult = attempt.kvResult;
+          break;
+        }
       }
-
-      const keyUnion = `vb:day:${ymd}:union`;
-      const fall2Raw = await kvGetRaw(keyUnion);
-      const fall2Value = toJson(fall2Raw);
-      const fall2Arr = arrFromAny(fall2Value);
-      if (wantDebug) {
-        const fall2JsonMeta = jsonMeta(fall2Raw, fall2Value);
-        const fall2ArrayMeta = arrayMeta(fall2Value, fall2Arr, fall2JsonMeta);
-        readMeta.push({ key: keyUnion, json: fall2JsonMeta, array: fall2ArrayMeta });
-      }
-
-      const keyLast = `vb:day:${ymd}:last`;
-      const fall3Raw = await kvGetRaw(keyLast);
-      const fall3Value = toJson(fall3Raw);
-      const fall3Arr = arrFromAny(fall3Value);
-      if (wantDebug) {
-        const fall3JsonMeta = jsonMeta(fall3Raw, fall3Value);
-        const fall3ArrayMeta = arrayMeta(fall3Value, fall3Arr, fall3JsonMeta);
-        readMeta.push({ key: keyLast, json: fall3JsonMeta, array: fall3ArrayMeta });
-      }
-
-      const fall1 = fall1Arr;
-      const fall2 = fall2Arr;
-      const fall3 = fall3Arr;
-      items = fall1.length ? fall1 : (fall2.length ? fall2 : fall3);
     }
 
-    // Sort po tier pa confidence, uz cap per league, UEFA do 6 ukupno
+    const resolvedFlavor = chosenFlavor || debugFlavor || "unknown";
+    const resolvedResult = chosenResult !== undefined ? chosenResult : debugResult;
+
     const countsByLeague = new Map();
     let uefaCnt = 0;
     const picked = [];
 
-    for (const it of items.sort((a,b)=>{
-      const la = String(a?.league?.name||"");
-      const lb = String(b?.league?.name||"");
-      const ta = tierScore(la), tb = tierScore(lb);
-      if (tb!==ta) return tb-ta;
-      return (confidence(b)-confidence(a));
+    for (const it of items.sort((a, b) => {
+      const la = String(a?.league?.name || "");
+      const lb = String(b?.league?.name || "");
+      const ta = tierScore(la);
+      const tb = tierScore(lb);
+      if (tb !== ta) return tb - ta;
+      return confidence(b) - confidence(a);
     })) {
-      const league = String(it?.league?.name||"");
+      const league = String(it?.league?.name || "");
       const key = (it?.league?.id ?? league).toString().toLowerCase();
 
-      // UEFA globalni dnevni cap (preko svih UEFA takmičenja)
       if (isUEFA(league)) {
         if (uefaCnt >= UEFA_DAILY_CAP) continue;
       } else {
@@ -136,12 +132,26 @@ export default async function handler(req, res) {
 
       picked.push(it);
       if (isUEFA(league)) uefaCnt++;
-      else countsByLeague.set(key, (countsByLeague.get(key)||0)+1);
-      if (picked.length >= 15) break;
+      else countsByLeague.set(key, (countsByLeague.get(key) || 0) + 1);
+      if (picked.length >= TIER1_CAP + TIER2_CAP + TIER3_CAP) break;
     }
 
-    return res.status(200).json({ ok:true, ymd, slot, items: picked.slice(0,15), debug: { reads: wantDebug ? readMeta : null } });
+    const payload = {
+      ok: true,
+      ymd,
+      slot,
+      items: picked.slice(0, 15),
+    };
+
+    if (wantDebug) {
+      payload.debug = {
+        sourceFlavor: resolvedFlavor,
+        kvObject: typeof resolvedResult === "object",
+      };
+    }
+
+    return res.status(200).json(payload);
   } catch (e) {
-    return res.status(200).json({ ok:false, error: String(e?.message||e) });
+    return res.status(200).json({ ok: false, error: String(e?.message || e) });
   }
 }

--- a/pages/api/insights-build.js
+++ b/pages/api/insights-build.js
@@ -1,5 +1,4 @@
 // pages/api/insights-build.js
-import { jsonMeta, arrayMeta } from "../../lib/kv-meta";
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 export const config = { api: { bodyParser: false } };
@@ -7,7 +6,12 @@ export const config = { api: { bodyParser: false } };
 /* ---------- TZ (samo TZ_DISPLAY) ---------- */
 function pickTZ() {
   const raw = (process.env.TZ_DISPLAY || "Europe/Belgrade").trim();
-  try { new Intl.DateTimeFormat("en-GB", { timeZone: raw }); return raw; } catch { return "Europe/Belgrade"; }
+  try {
+    new Intl.DateTimeFormat("en-GB", { timeZone: raw });
+    return raw;
+  } catch {
+    return "Europe/Belgrade";
+  }
 }
 const TZ = pickTZ();
 
@@ -16,171 +20,189 @@ function kvBackends() {
   const out = [];
   const aU = process.env.KV_REST_API_URL, aT = process.env.KV_REST_API_TOKEN;
   const bU = process.env.UPSTASH_REDIS_REST_URL, bT = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (aU && aT) out.push({ flavor:"vercel-kv", url:aU.replace(/\/+$/,""), tok:aT });
-  if (bU && bT) out.push({ flavor:"upstash-redis", url:bU.replace(/\/+$/,""), tok:bT });
+  if (aU && aT) out.push({ flavor: "vercel-kv", url: aU.replace(/\/+$/, ""), tok: aT });
+  if (bU && bT) out.push({ flavor: "upstash-redis", url: bU.replace(/\/+$/, ""), tok: bT });
   return out;
 }
-async function kvGETraw(key, trace) {
+async function kvGETitems(key, trace) {
   for (const b of kvBackends()) {
     try {
-      const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`,{ headers:{ Authorization:`Bearer ${b.tok}` }, cache:"no-store" });
-      const j = await r.json().catch(()=>null);
-      const payload = j?.result ?? j?.value;
-      let raw = null;
-      if (typeof payload === "string") {
-        raw = payload;
-      } else if (payload !== undefined) {
-        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
-      }
-      trace && trace.push({ get:key, ok:r.ok, flavor:b.flavor, hit: typeof raw === "string" });
+      const r = await fetch(`${b.url}/get/${encodeURIComponent(key)}`, {
+        headers: { Authorization: `Bearer ${b.tok}` },
+        cache: "no-store",
+      });
+      const j = await r.json().catch(() => null);
+      const res = j && ("result" in j ? j.result : j);
+      const obj = toJson(res);
+      const items = arrFromAny(obj);
+      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, count: items.length });
       if (!r.ok) continue;
-      return { raw, flavor:b.flavor };
-    } catch (e) { trace && trace.push({ get:key, ok:false, err:String(e?.message||e) }); }
+      return { items, obj, flavor: b.flavor, kvResult: res };
+    } catch (e) {
+      trace && trace.push({ get: key, ok: false, err: String(e?.message || e) });
+    }
   }
-  return { raw:null, flavor:null };
+  return { items: [], obj: null, flavor: null, kvResult: null };
 }
 async function kvSET(key, value, trace) {
   const saved = [];
-  const body = (typeof value === "string") ? value : JSON.stringify(value);
+  const body = typeof value === "string" ? value : JSON.stringify(value);
   for (const b of kvBackends()) {
     try {
-      const r = await fetch(`${b.url}/set/${encodeURIComponent(key)}`,{
-        method:"POST", headers:{ Authorization:`Bearer ${b.tok}`, "Content-Type":"application/json" }, cache:"no-store", body
+      const r = await fetch(`${b.url}/set/${encodeURIComponent(key)}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${b.tok}`, "Content-Type": "application/json" },
+        cache: "no-store",
+        body,
       });
-      saved.push({ flavor:b.flavor, ok:r.ok });
-    } catch (e) { saved.push({ flavor:b.flavor, ok:false, err:String(e?.message||e) }); }
+      saved.push({ flavor: b.flavor, ok: r.ok });
+    } catch (e) {
+      saved.push({ flavor: b.flavor, ok: false, err: String(e?.message || e) });
+    }
   }
-  trace && trace.push({ set:key, saved }); return saved;
+  trace && trace.push({ set: key, saved });
+  return saved;
 }
 
 /* ---------- utils ---------- */
 const ymdInTZ = (d, tz) => new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(d);
-const hourInTZ = (d, tz) => Number(new Intl.DateTimeFormat("en-GB", { timeZone: tz, hour12:false, hour:"2-digit" }).format(d));
-function canonicalSlot(x){ x=String(x||"auto").toLowerCase(); return x==="late"||x==="am"||x==="pm"?x:"auto"; }
-function autoSlot(d,tz){ const h=hourInTZ(d,tz); return h<10?"late":(h<15?"am":"pm"); }
+const hourInTZ = (d, tz) => Number(new Intl.DateTimeFormat("en-GB", { timeZone: tz, hour12: false, hour: "2-digit" }).format(d));
+function canonicalSlot(x) {
+  x = String(x || "auto").toLowerCase();
+  return x === "late" || x === "am" || x === "pm" ? x : "auto";
+}
+function autoSlot(d, tz) {
+  const h = hourInTZ(d, tz);
+  return h < 10 ? "late" : h < 15 ? "am" : "pm";
+}
 // Uvek "danas" (workflow prosleđuje ymd kad je drugi dan potreban)
-function targetYmdForSlot(now, slot, tz){ return ymdInTZ(now, tz); }
-const isValidYmd = (s)=> /^\d{4}-\d{2}-\d{2}$/.test(String(s||""));
+function targetYmdForSlot(now, slot, tz) {
+  return ymdInTZ(now, tz);
+}
+const isValidYmd = (s) => /^\d{4}-\d{2}-\d{2}$/.test(String(s || ""));
 
 /* ---------- selection helpers ---------- */
-const num = v => Number.isFinite(v) ? v : Number(v);
-const MIN_ODDS = (()=>{ const v=Number(process.env.MIN_ODDS); return Number.isFinite(v)&&v>1 ? v : 1.5; })();
-const pickPrice = (v)=>{ const n=num(v); return Number.isFinite(n) ? n : null; };
-const kickoffISO = (it)=> it?.fixture?.date || it?.fixture_date || it?.kickoff || it?.kickoff_utc || it?.ts || null;
-const confPct = (it)=> Number.isFinite(it?.confidence_pct) ? it.confidence_pct : (Number(it?.confidence)||0);
-const byStrength = (a,b)=> (confPct(b)-confPct(a)) || (new Date(kickoffISO(a)).getTime() - new Date(kickoffISO(b)).getTime());
+const num = (v) => (Number.isFinite(v) ? v : Number(v));
+const MIN_ODDS = (() => {
+  const v = Number(process.env.MIN_ODDS);
+  return Number.isFinite(v) && v > 1 ? v : 1.5;
+})();
+const pickPrice = (v) => {
+  const n = num(v);
+  return Number.isFinite(n) ? n : null;
+};
+const kickoffISO = (it) => it?.fixture?.date || it?.fixture_date || it?.kickoff || it?.kickoff_utc || it?.ts || null;
+const confPct = (it) => (Number.isFinite(it?.confidence_pct) ? it.confidence_pct : Number(it?.confidence) || 0);
+const byStrength = (a, b) => confPct(b) - confPct(a) || new Date(kickoffISO(a)).getTime() - new Date(kickoffISO(b)).getTime();
 
 /* ---------- tickets snapshot record ---------- */
-function snapshotItem(it, market_key, price, books_count, pick, extra={}){
+function snapshotItem(it, market_key, price, books_count, pick, extra = {}) {
   const fx = it?.fixture?.id || it?.fixture_id || it?.id || null;
   return {
     fixture_id: fx,
     league: it?.league || it?.fixture?.league || null,
     teams: it?.teams || it?.fixture?.teams || null,
     kickoff: kickoffISO(it),
-    market_key, pick,
+    market_key,
+    pick,
     price_snapshot: price ?? null,
-    books_count_snapshot: Number(books_count)||0,
+    books_count_snapshot: Number(books_count) || 0,
     frozen: true,
     snapshot_at: new Date().toISOString(),
-    ...extra
+    ...extra,
   };
 }
 
 /* ---------- derive helpers for Top-3 ---------- */
 function marketPickFromItem(it) {
-  // Prefer canonical fields if postoje
   const mk = (it?.market_key || it?.market || "").toString().toLowerCase();
   const pickTxt = (it?.pick || it?.selection_label || "").toString().toLowerCase();
   const m = it?.markets || {};
-  // Mapiraj na interni ključ + izvuci cenu iz markets.* ako postoji
   if (/^h2h|1x2|match\s*winn?er/.test(mk)) {
-    // pokušaj prepoznati smer iz it.pick (home/draw/away)
     let side = null;
     if (/home|1\b/.test(pickTxt)) side = "home";
     else if (/draw|x\b|tie/.test(pickTxt)) side = "draw";
     else if (/away|2\b/.test(pickTxt)) side = "away";
     const price = side ? m?.h2h?.[side] : null;
-    return { market_key:"h2h", pick: side || "home", price: price ?? null, books: m?.h2h?.books_count };
+    return { market_key: "h2h", pick: side || "home", price: price ?? null, books: m?.h2h?.books_count };
   }
   if (/btts|both\s*teams\s*to\s*score/.test(mk)) {
     const price = m?.btts?.yes ?? null;
-    return { market_key:"btts", pick:"yes", price, books: m?.btts?.books_count };
+    return { market_key: "btts", pick: "yes", price, books: m?.btts?.books_count };
   }
   if (/ou|over\/under|goals/.test(mk) || /2\.5/.test(pickTxt)) {
     const price = m?.ou25?.over ?? null;
-    return { market_key:"ou25", pick:"over", price, books: m?.ou25?.books_count };
+    return { market_key: "ou25", pick: "over", price, books: m?.ou25?.books_count };
   }
   if (/ht\s*\/\s*ft|htft|half\s*time.*full\s*time/.test(mk)) {
-    const hh = m?.htft?.hh, aa = m?.htft?.aa;
-    const chose = Number.isFinite(hh) && Number.isFinite(aa) ? (hh>=aa?{p:hh,code:"hh"}:{p:aa,code:"aa"})
-                 : Number.isFinite(hh) ? {p:hh,code:"hh"} : Number.isFinite(aa) ? {p:aa,code:"aa"} : null;
-    return chose ? { market_key:"htft", pick:chose.code, price:chose.p, books:m?.htft?.books_count } : null;
+    const hh = m?.htft?.hh;
+    const aa = m?.htft?.aa;
+    const chose = Number.isFinite(hh) && Number.isFinite(aa)
+      ? (hh >= aa ? { p: hh, code: "hh" } : { p: aa, code: "aa" })
+      : Number.isFinite(hh)
+      ? { p: hh, code: "hh" }
+      : Number.isFinite(aa)
+      ? { p: aa, code: "aa" }
+      : null;
+    return chose ? { market_key: "htft", pick: chose.code, price: chose.p, books: m?.htft?.books_count } : null;
   }
   if (/fh|first.*half/.test(mk)) {
     const price = m?.fh_ou15?.over ?? null;
-    return { market_key:"fh_ou15", pick:"over", price, books:m?.fh_ou15?.books_count };
+    return { market_key: "fh_ou15", pick: "over", price, books: m?.fh_ou15?.books_count };
   }
   return null;
 }
 
 /* ---------- merge Top-3 + tickets u vb:day:<ymd>:combined ---------- */
-function dedupKey(e){
+function dedupKey(e) {
   const f = e?.fixture_id || e?.fixture?.id || e?.id;
-  return `${f || "?"}__${String(e?.market_key||"").toLowerCase()}__${String(e?.pick||"").toLowerCase()}`;
+  return `${f || "?"}__${String(e?.market_key || "").toLowerCase()}__${String(e?.pick || "").toLowerCase()}`;
 }
-async function mergeCombined({ ymd, slot, top3Items, ticketsSnap, trace, wantDebug = false }) {
+async function mergeCombined({ ymd, slot, top3Items, ticketsSnap, trace }) {
   const key = `vb:day:${ymd}:combined`;
-  const { raw: prevRaw } = await kvGETraw(key, trace);
-  const prevValue = toJson(prevRaw);
-  const prevArr = arrFromAny(prevValue);
-  const prev = prevArr || [];
-  const traceEntry = { combined_key: key };
-  if (wantDebug) {
-    const prevJsonMeta = jsonMeta(prevRaw, prevValue);
-    const prevArrayMeta = arrayMeta(prevValue, prevArr, prevJsonMeta);
-    traceEntry.read_meta = { json: prevJsonMeta, array: prevArrayMeta };
-  }
-  const by = new Map(prev.map(e => [dedupKey(e), e]));
+  const prev = await kvGETitems(key, trace);
+  const prevArr = prev.items || [];
+  const by = new Map(prevArr.map((e) => [dedupKey(e), e]));
   let added = 0;
 
-  // 1) Top-3: pretvori u snapshot zapise
-  for (const it of (top3Items||[])) {
+  for (const it of top3Items || []) {
     const mp = marketPickFromItem(it);
     if (!mp) continue;
     const entry = snapshotItem(it, mp.market_key, mp.price, mp.books, mp.pick, {
       source: "top3",
-      slot
+      slot,
     });
-    entry.visible_for_history = (entry.market_key === "h2h"); // History vidi samo h2h
+    entry.visible_for_history = entry.market_key === "h2h";
     const keyD = dedupKey(entry);
-    if (!by.has(keyD)) { by.set(keyD, entry); added++; }
-  }
-
-  // 2) Tiketi 4×4: već su snap-ovani; samo dodaj meta i dedup
-  function enrichAndAdd(list, market_key) {
-    for (const row of (list||[])) {
-      const e = { ...row, source:"ticket", slot, market_key: market_key || row.market_key };
-      e.visible_for_history = (e.market_key === "h2h");
-      const keyD = dedupKey(e);
-      if (!by.has(keyD)) { by.set(keyD, e); added++; }
+    if (!by.has(keyD)) {
+      by.set(keyD, entry);
+      added++;
     }
   }
-  enrichAndAdd(ticketsSnap?.btts,   "btts");
-  enrichAndAdd(ticketsSnap?.ou25,   "ou25");
-  enrichAndAdd(ticketsSnap?.htft,   "htft");
-  enrichAndAdd(ticketsSnap?.fh_ou15,"fh_ou15");
+
+  function enrichAndAdd(list, market_key) {
+    for (const row of list || []) {
+      const e = { ...row, source: "ticket", slot, market_key: market_key || row.market_key };
+      e.visible_for_history = e.market_key === "h2h";
+      const keyD = dedupKey(e);
+      if (!by.has(keyD)) {
+        by.set(keyD, e);
+        added++;
+      }
+    }
+  }
+  enrichAndAdd(ticketsSnap?.btts, "btts");
+  enrichAndAdd(ticketsSnap?.ou25, "ou25");
+  enrichAndAdd(ticketsSnap?.htft, "htft");
+  enrichAndAdd(ticketsSnap?.fh_ou15, "fh_ou15");
 
   if (added > 0) {
     const merged = Array.from(by.values());
     await kvSET(key, merged, trace);
-    traceEntry.added = added;
-    traceEntry.total = merged.length;
+    trace && trace.push({ combined_key: key, added, total: merged.length });
   } else {
-    traceEntry.added = 0;
-    traceEntry.note = "no-op";
+    trace && trace.push({ combined_key: key, added: 0, note: "no-op" });
   }
-  trace && trace.push(traceEntry);
 }
 
 export default async function handler(req, res) {
@@ -188,99 +210,126 @@ export default async function handler(req, res) {
     const trace = [];
     const now = new Date();
     const wantDebug = String(req.query?.debug || "") === "1";
-    const readMeta = wantDebug ? [] : null;
 
     const qSlot = canonicalSlot(req.query.slot);
-    const slot  = qSlot==="auto" ? autoSlot(now, TZ) : qSlot;
+    const slot = qSlot === "auto" ? autoSlot(now, TZ) : qSlot;
 
-    const qYmd = String(req.query.ymd||"").trim();
-    const ymd  = isValidYmd(qYmd) ? qYmd : targetYmdForSlot(now, slot, TZ);
+    const qYmd = String(req.query.ymd || "").trim();
+    const ymd = isValidYmd(qYmd) ? qYmd : targetYmdForSlot(now, slot, TZ);
 
-    /* kandidati: prefer vbl_full → vbl → vb:day:<slot> → vb:day:union */
-    const tried = [
-      `vbl_full:${ymd}:${slot}`,
-      `vbl:${ymd}:${slot}`,
-      `vb:day:${ymd}:${slot}`,
-      `vb:day:${ymd}:union`
-    ];
-    let baseArr=null, source=null;
-    for (const k of tried) {
-      const { raw } = await kvGETraw(k, trace);
-      const jsonValue = toJson(raw);
-      const arr = arrFromAny(jsonValue);
-      if (wantDebug) {
-        const metaJson = jsonMeta(raw, jsonValue);
-        const metaArray = arrayMeta(jsonValue, arr, metaJson);
-        readMeta.push({ key: k, json: metaJson, array: metaArray });
+    const tried = [`vbl_full:${ymd}:${slot}`, `vbl:${ymd}:${slot}`, `vb:day:${ymd}:${slot}`, `vb:day:${ymd}:union`];
+    let baseArr = null;
+    let source = null;
+    let chosenFlavor = null;
+    let chosenResult;
+    let debugFlavor = null;
+    let debugResult;
+
+    for (const key of tried) {
+      const attempt = await kvGETitems(key, trace);
+      if (!debugFlavor && attempt.flavor) debugFlavor = attempt.flavor;
+      if (debugResult === undefined && attempt.kvResult !== undefined) debugResult = attempt.kvResult;
+      if (attempt.items.length) {
+        baseArr = attempt.items;
+        source = key;
+        chosenFlavor = attempt.flavor;
+        chosenResult = attempt.kvResult;
+        break;
       }
-      if (arr.length){ baseArr=arr; source=k; break; }
     }
+
+    const resolvedFlavor = chosenFlavor || debugFlavor || "unknown";
+    const resolvedResult = chosenResult !== undefined ? chosenResult : debugResult;
 
     if (!baseArr) {
-      return res.status(200).json({ ok:true, ymd, slot, source:null, counts:{btts:0,ou25:0,htft:0,fh_ou15:0}, note:"no-source-items", debug:{ trace, reads: wantDebug ? readMeta : null } });
+      const payload = {
+        ok: true,
+        ymd,
+        slot,
+        source: null,
+        counts: { btts: 0, ou25: 0, htft: 0, fh_ou15: 0 },
+        note: "no-source-items",
+      };
+      if (wantDebug) {
+        payload.debug = {
+          sourceFlavor: resolvedFlavor,
+          kvObject: typeof resolvedResult === "object",
+        };
+      }
+      return res.status(200).json(payload);
     }
 
-    // --- rangiranje za izbor ---
-    const sorted = baseArr.slice().sort((a,b)=> byStrength(a,b));
+    const sorted = baseArr.slice().sort((a, b) => byStrength(a, b));
 
-    // --- grupisanje za 4×4 ---
-    const groups = { btts:[], ou25:[], htft:[], fh_ou15:[] };
+    const groups = { btts: [], ou25: [], htft: [], fh_ou15: [] };
     for (const it of baseArr) {
       const m = it?.markets || {};
       if (m?.btts) {
         const p = pickPrice(m.btts.yes);
-        if (p && p >= MIN_ODDS) groups.btts.push({ it, price:p, books:m?.btts?.books_count, pick:"yes" });
+        if (p && p >= MIN_ODDS) groups.btts.push({ it, price: p, books: m?.btts?.books_count, pick: "yes" });
       }
       if (m?.ou25) {
         const p = pickPrice(m.ou25.over);
-        if (p && p >= MIN_ODDS) groups.ou25.push({ it, price:p, books:m?.ou25?.books_count, pick:"over" });
+        if (p && p >= MIN_ODDS) groups.ou25.push({ it, price: p, books: m?.ou25?.books_count, pick: "over" });
       }
       if (m?.htft) {
         const hh = pickPrice(m.htft.hh);
         const aa = pickPrice(m.htft.aa);
-        const chosen = (hh && aa) ? (hh >= aa ? {p:hh, code:"hh"} : {p:aa, code:"aa"}) : (hh ? {p:hh, code:"hh"} : (aa ? {p:aa, code:"aa"} : null));
-        if (chosen && chosen.p >= MIN_ODDS) groups.htft.push({ it, price:chosen.p, books:m?.htft?.books_count, pick:chosen.code });
+        const chosen = hh && aa ? (hh >= aa ? { p: hh, code: "hh" } : { p: aa, code: "aa" }) : hh ? { p: hh, code: "hh" } : aa ? { p: aa, code: "aa" } : null;
+        if (chosen && chosen.p >= MIN_ODDS) groups.htft.push({ it, price: chosen.p, books: m?.htft?.books_count, pick: chosen.code });
       }
       if (m?.fh_ou15) {
         const p = pickPrice(m.fh_ou15.over);
-        if (p && p >= MIN_ODDS) groups.fh_ou15.push({ it, price:p, books:m?.fh_ou15?.books_count, pick:"over" });
+        if (p && p >= MIN_ODDS) groups.fh_ou15.push({ it, price: p, books: m?.fh_ou15?.books_count, pick: "over" });
       }
     }
-    for (const k of Object.keys(groups)) groups[k].sort((a,b)=> byStrength(a.it,b.it));
+    for (const k of Object.keys(groups)) groups[k].sort((a, b) => byStrength(a.it, b.it));
 
-    // --- izaberi top ---
     const top = {
-      btts: groups.btts.slice(0,4),
-      ou25: groups.ou25.slice(0,4),
-      htft: groups.htft.slice(0,4),
-      fh_ou15: groups.fh_ou15.slice(0,4)
+      btts: groups.btts.slice(0, 4),
+      ou25: groups.ou25.slice(0, 4),
+      htft: groups.htft.slice(0, 4),
+      fh_ou15: groups.fh_ou15.slice(0, 4),
     };
 
     const totalNew = top.btts.length + top.ou25.length + top.htft.length + top.fh_ou15.length;
     const keySlot = `tickets:${ymd}:${slot}`;
 
     if (totalNew === 0) {
-      // No-clobber za tiket
-      trace.push({ note:"no-clobber (no-valid-candidates)" });
-      return res.status(200).json({ ok:true, ymd, slot, source, counts:{btts:0,ou25:0,htft:0,fh_ou15:0}, debug:{ trace } });
+      const payload = {
+        ok: true,
+        ymd,
+        slot,
+        source,
+        counts: { btts: 0, ou25: 0, htft: 0, fh_ou15: 0 },
+        note: "no-clobber (no-valid-candidates)",
+      };
+      if (wantDebug) {
+        payload.debug = {
+          sourceFlavor: resolvedFlavor,
+          kvObject: typeof resolvedResult === "object",
+        };
+      }
+      return res.status(200).json(payload);
     }
 
-    // --- snap tiketa ---
-    const snap = { btts:[], ou25:[], htft:[], fh_ou15:[] };
-    for (const row of top.btts)    snap.btts.push(snapshotItem(row.it,   "btts",     row.price, row.books, row.pick));
-    for (const row of top.ou25)    snap.ou25.push(snapshotItem(row.it,   "ou25",     row.price, row.books, row.pick));
-    for (const row of top.htft)    snap.htft.push(snapshotItem(row.it,   "htft",     row.price, row.books, row.pick));
-    for (const row of top.fh_ou15) snap.fh_ou15.push(snapshotItem(row.it,"fh_ou15",  row.price, row.books, row.pick));
+    const snap = { btts: [], ou25: [], htft: [], fh_ou15: [] };
+    for (const row of top.btts) snap.btts.push(snapshotItem(row.it, "btts", row.price, row.books, row.pick));
+    for (const row of top.ou25) snap.ou25.push(snapshotItem(row.it, "ou25", row.price, row.books, row.pick));
+    for (const row of top.htft) snap.htft.push(snapshotItem(row.it, "htft", row.price, row.books, row.pick));
+    for (const row of top.fh_ou15) snap.fh_ou15.push(snapshotItem(row.it, "fh_ou15", row.price, row.books, row.pick));
 
-    // upiši tiket po slotu, a dnevni samo ako ne postoji
     await kvSET(keySlot, snap, trace);
-    const { raw:rawDay } = await kvGETraw(`tickets:${ymd}`, trace);
-    const dayValue = toJson(rawDay);
-    const jDay = dayValue && typeof dayValue === "object" ? dayValue : null;
-    const hasDay = jDay && (Array.isArray(jDay.btts)||Array.isArray(jDay.ou25)||Array.isArray(jDay.htft)||Array.isArray(jDay.fh_ou15));
+    const day = await kvGETitems(`tickets:${ymd}`, trace);
+    const dayValue = day.obj;
+    const hasDay = dayValue && typeof dayValue === "object" && (
+      Array.isArray(dayValue.btts) ||
+      Array.isArray(dayValue.ou25) ||
+      Array.isArray(dayValue.htft) ||
+      Array.isArray(dayValue.fh_ou15)
+    );
     if (!hasDay) await kvSET(`tickets:${ymd}`, snap, trace);
 
-    // --- NEW: pripremi Top-3 iz sorted (uz snapshot) ---
     const top3 = [];
     for (const it of sorted.slice(0, 3)) {
       const mp = marketPickFromItem(it);
@@ -288,13 +337,32 @@ export default async function handler(req, res) {
       top3.push({ it, ...mp });
     }
 
-    // --- NEW: merge Top-3 + 4×4 u vb:day:<ymd>:combined (no-clobber & dedup) ---
-    await mergeCombined({ ymd, slot, top3Items: top3.map(x=>x.it), ticketsSnap: snap, trace, wantDebug });
+    await mergeCombined({ ymd, slot, top3Items: top3.map((x) => x.it), ticketsSnap: snap, trace });
 
-    const counts = { btts: snap.btts.length, ou25: snap.ou25.length, htft: snap.htft.length, fh_ou15: snap.fh_ou15.length };
-    return res.status(200).json({ ok:true, ymd, slot, source, tickets_key:keySlot, counts, min_odds:MIN_ODDS, debug:{ trace, reads: wantDebug ? readMeta : null } });
+    const counts = {
+      btts: snap.btts.length,
+      ou25: snap.ou25.length,
+      htft: snap.htft.length,
+      fh_ou15: snap.fh_ou15.length,
+    };
 
+    const payload = {
+      ok: true,
+      ymd,
+      slot,
+      source,
+      tickets_key: keySlot,
+      counts,
+      min_odds: MIN_ODDS,
+    };
+    if (wantDebug) {
+      payload.debug = {
+        sourceFlavor: resolvedFlavor,
+        kvObject: typeof resolvedResult === "object",
+      };
+    }
+    return res.status(200).json(payload);
   } catch (e) {
-    return res.status(200).json({ ok:false, error:String(e?.message||e) });
+    return res.status(200).json({ ok: false, error: String(e?.message || e) });
   }
 }


### PR DESCRIPTION
## Summary
- replace the kv-read helper with a tolerant JSON/array reader and update the history, ROI, crypto, football, and insights APIs to use the new parsing flow with optional debug payloads
- add focused unit tests that cover kv-read helpers and the history API's ability to handle both string and object envelopes, and refresh the normalization suite for the trimmed debug output
- ship a smoke-history script, developer docs, and a GitHub Actions workflow that builds, runs tests, boots the app, and hits the history endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd62668f1c8322a6406ea1516b4960