### PR TITLE
Normalize fallback markets in history endpoints

### DIFF
--- a/__tests__/pages/api/history-market-fallback.test.js
+++ b/__tests__/pages/api/history-market-fallback.test.js
@@ -1,0 +1,103 @@
+const sampleHistoryPayload = {
+  history: [
+    {
+      fixture_id: "fx-allow-1",
+      market: "1x2",
+      pick: "home",
+      result: "win",
+      price_snapshot: 2.25,
+    },
+  ],
+};
+
+const realFetch = global.fetch;
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+const kvResponseModes = [
+  ["string payloads", (payload) => ({ result: JSON.stringify(payload) })],
+  ["object payloads", (payload) => ({ result: payload })],
+];
+
+describe.each(kvResponseModes)("API history market fallback (%s)", (modeLabel, makeEnvelope) => {
+  function mockKvResponses(fetchMock, payload) {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeEnvelope(payload),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.HISTORY_ALLOWED_MARKETS = "1x2";
+    process.env.KV_REST_API_URL = "https://kv.example";
+    process.env.KV_REST_API_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    if (realFetch) {
+      global.fetch = realFetch;
+    } else {
+      delete global.fetch;
+    }
+    delete process.env.HISTORY_ALLOWED_MARKETS;
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+  });
+
+  it("surfaces entries whose market key is stored under the market field", async () => {
+    const fetchMock = jest.fn();
+    mockKvResponses(fetchMock, sampleHistoryPayload);
+    global.fetch = fetchMock;
+
+    const { default: handler } = require("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-06-01", debug: "1" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.count).toBe(1);
+    expect(res.jsonPayload.history.map((e) => e.market)).toContain("1x2");
+    expect(res.jsonPayload.debug.allowed).toEqual(["1x2"]);
+  });
+
+  it("includes market fallback entries when computing ROI", async () => {
+    const fetchMock = jest.fn();
+    mockKvResponses(fetchMock, sampleHistoryPayload);
+    global.fetch = fetchMock;
+
+    const { default: handler } = require("../../../pages/api/history-roi");
+
+    const req = { query: { ymd: "2024-06-01", debug: "1" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.count).toBe(1);
+    expect(res.jsonPayload.roi).toMatchObject({ played: 1, wins: 1 });
+    expect(res.jsonPayload.debug.allowed).toEqual(["1x2"]);
+  });
+});
+

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -57,7 +57,8 @@ function parseAllowedMarkets(envVal) {
 const allowSet = parseAllowedMarkets(process.env.HISTORY_ALLOWED_MARKETS);
 
 function dedupKey(e, normalizedMarketKey) {
-  const m = normalizedMarketKey ?? normalizeMarketKey(e?.market_key);
+  const rawMarket = e?.market_key ?? e?.market ?? e?.market_label;
+  const m = normalizedMarketKey ?? normalizeMarketKey(rawMarket);
   const pick = String(e?.pick || "").toLowerCase().trim();
   return `${e?.fixture_id || e?.id || "?"}__${m}__${pick}`;
 }
@@ -65,7 +66,8 @@ function dedupKey(e, normalizedMarketKey) {
 function filterAllowed(arr) {
   const by = new Map();
   for (const e of (arr || [])) {
-    const mkey = normalizeMarketKey(e?.market_key);
+    const rawMarket = e?.market_key ?? e?.market ?? e?.market_label;
+    const mkey = normalizeMarketKey(rawMarket);
     if (!mkey || !allowSet.has(mkey)) continue;
     const k = dedupKey(e, mkey);
     if (!by.has(k)) by.set(k, e);

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -70,7 +70,8 @@ function parseAllowedMarkets(envVal) {
 const allowSet = parseAllowedMarkets(process.env.HISTORY_ALLOWED_MARKETS);
 
 const dedupKey = (e, normalizedMarketKey) => {
-  const m = normalizedMarketKey ?? normalizeMarketKey(e?.market_key);
+  const rawMarket = e?.market_key ?? e?.market ?? e?.market_label;
+  const m = normalizedMarketKey ?? normalizeMarketKey(rawMarket);
   const pick = String(e?.pick || "").toLowerCase().trim();
   return `${e?.fixture_id || e?.id || "?"}__${m}__${pick}`;
 };
@@ -78,7 +79,8 @@ const dedupKey = (e, normalizedMarketKey) => {
 function filterAllowed(arr) {
   const by = new Map();
   for (const e of (arr || [])) {
-    const mkey = normalizeMarketKey(e?.market_key);
+    const rawMarket = e?.market_key ?? e?.market ?? e?.market_label;
+    const mkey = normalizeMarketKey(rawMarket);
     if (!mkey || !allowSet.has(mkey)) continue;
     const k = dedupKey(e, mkey);
     if (!by.has(k)) by.set(k, e);


### PR DESCRIPTION
## Summary
- normalize history API market lookups using market, market_key or market_label before dedupe
- apply the same fallback logic to the ROI endpoint so aggregated results stay consistent
- add regression coverage that ensures a 1x2 market stored under `market` surfaces in history and ROI responses when allowed

## Testing
- npm test *(fails: existing lib/kv-read tests expect metadata wrappers that the current helpers do not return)*
- npx jest __tests__/pages/api/history-normalization.test.js __tests__/pages/api/history-market-fallback.test.js


------
https://chatgpt.com/codex/tasks/task_e_68cd7f4ce2d0832298c53dafaeb98919