### PR TITLE
Enhance KV read helpers metadata

### DIFF
--- a/lib/kv-read.js
+++ b/lib/kv-read.js
@@ -1,41 +1,80 @@
-export function toJson(val) {
-  if (typeof val === "string") {
-    const trimmed = val.trim();
-    if (!trimmed) return null;
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      return null;
-    }
-  }
+import { arrayMeta, jsonMeta } from "./kv-meta";
 
-  if (val && typeof val === "object") {
+function normalizePrimitiveValue(val) {
+  if (typeof val === "number" || typeof val === "boolean") {
     return val;
   }
-
-  if (typeof val === "number" || typeof val === "boolean") {
+  if (val == null) {
     return null;
   }
-
   return null;
 }
 
+export function toJson(val) {
+  let value;
+  let parseFailed = false;
+
+  if (typeof val === "string") {
+    const trimmed = val.trim();
+    if (!trimmed) {
+      value = null;
+    } else {
+      try {
+        value = JSON.parse(trimmed);
+      } catch {
+        value = null;
+        parseFailed = true;
+      }
+    }
+  } else if (val && typeof val === "object") {
+    value = val;
+  } else {
+    value = normalizePrimitiveValue(val);
+  }
+
+  const meta = jsonMeta(val, value);
+  if (parseFailed) {
+    meta.error = "invalid_json";
+    meta.parsed = false;
+  }
+
+  return { value, meta };
+}
+
+function isWrappedJson(input) {
+  return (
+    input &&
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    Object.prototype.hasOwnProperty.call(input, "value") &&
+    Object.prototype.hasOwnProperty.call(input, "meta") &&
+    typeof input.meta === "object"
+  );
+}
+
 export function arrFromAny(input) {
-  if (Array.isArray(input)) {
-    return input;
+  let sourceValue = input;
+  let baseMeta = null;
+
+  if (isWrappedJson(input)) {
+    baseMeta = input.meta;
+    sourceValue = input.value;
   }
 
-  if (input && typeof input === "object") {
-    if (Array.isArray(input.items)) {
-      return input.items;
-    }
-    if (Array.isArray(input.history)) {
-      return input.history;
-    }
-    if (Array.isArray(input.list)) {
-      return input.list;
+  let array = [];
+
+  if (Array.isArray(sourceValue)) {
+    array = sourceValue;
+  } else if (sourceValue && typeof sourceValue === "object") {
+    if (Array.isArray(sourceValue.items)) {
+      array = sourceValue.items;
+    } else if (Array.isArray(sourceValue.history)) {
+      array = sourceValue.history;
+    } else if (Array.isArray(sourceValue.list)) {
+      array = sourceValue.list;
     }
   }
 
-  return [];
+  const meta = arrayMeta(sourceValue ?? null, array, baseMeta);
+  return { array, meta };
 }

--- a/pages/api/crypto-history-day.js
+++ b/pages/api/crypto-history-day.js
@@ -78,13 +78,13 @@ export default async function handler(req, res) {
     const idxRaw = await kvGETraw("crypto:history:index");
     const idxValue = toJson(idxRaw);
     const idxArr = arrFromAny(idxValue);
-    const ids = idxArr.slice(-800).reverse(); // recent → old
+    const ids = idxArr.array.slice(-800).reverse(); // recent → old
 
     const items = [];
     for (const id of ids) {
       const raw = await kvGETraw(`crypto:history:item:${id}`);
       const itValue = toJson(raw);
-      const it = itValue && typeof itValue === "object" ? itValue : null;
+      const it = itValue.value && typeof itValue.value === "object" ? itValue.value : null;
       if (!it) continue;
 
       // probaj redom: ts (created), evaluated_ts, valid_until

--- a/pages/api/football.js
+++ b/pages/api/football.js
@@ -1,5 +1,4 @@
 // pages/api/football.js
-import { jsonMeta, arrayMeta } from "../../lib/kv-meta";
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 export const config = { api: { bodyParser: false } };
@@ -67,11 +66,11 @@ export default async function handler(req, res) {
     const fullValue = toJson(fullRaw);
     const fullArr = arrFromAny(fullValue);
     if (wantDebug) {
-      const fullJsonMeta = jsonMeta(fullRaw, fullValue);
-      const fullArrayMeta = arrayMeta(fullValue, fullArr, fullJsonMeta);
+      const fullJsonMeta = { ...fullValue.meta };
+      const fullArrayMeta = { ...fullArr.meta };
       readMeta.push({ key: fullKey, json: fullJsonMeta, array: fullArrayMeta });
     }
-    let items = fullArr;
+    let items = fullArr.array;
 
     // Fallback: uzmi vb:day:<ymd>:<slot> / union / last (bez poziva frontu)
     if (!items.length) {
@@ -80,8 +79,8 @@ export default async function handler(req, res) {
       const fall1Value = toJson(fall1Raw);
       const fall1Arr = arrFromAny(fall1Value);
       if (wantDebug) {
-        const fall1JsonMeta = jsonMeta(fall1Raw, fall1Value);
-        const fall1ArrayMeta = arrayMeta(fall1Value, fall1Arr, fall1JsonMeta);
+        const fall1JsonMeta = { ...fall1Value.meta };
+        const fall1ArrayMeta = { ...fall1Arr.meta };
         readMeta.push({ key: keySlot, json: fall1JsonMeta, array: fall1ArrayMeta });
       }
 
@@ -90,8 +89,8 @@ export default async function handler(req, res) {
       const fall2Value = toJson(fall2Raw);
       const fall2Arr = arrFromAny(fall2Value);
       if (wantDebug) {
-        const fall2JsonMeta = jsonMeta(fall2Raw, fall2Value);
-        const fall2ArrayMeta = arrayMeta(fall2Value, fall2Arr, fall2JsonMeta);
+        const fall2JsonMeta = { ...fall2Value.meta };
+        const fall2ArrayMeta = { ...fall2Arr.meta };
         readMeta.push({ key: keyUnion, json: fall2JsonMeta, array: fall2ArrayMeta });
       }
 
@@ -100,14 +99,14 @@ export default async function handler(req, res) {
       const fall3Value = toJson(fall3Raw);
       const fall3Arr = arrFromAny(fall3Value);
       if (wantDebug) {
-        const fall3JsonMeta = jsonMeta(fall3Raw, fall3Value);
-        const fall3ArrayMeta = arrayMeta(fall3Value, fall3Arr, fall3JsonMeta);
+        const fall3JsonMeta = { ...fall3Value.meta };
+        const fall3ArrayMeta = { ...fall3Arr.meta };
         readMeta.push({ key: keyLast, json: fall3JsonMeta, array: fall3ArrayMeta });
       }
 
-      const fall1 = fall1Arr;
-      const fall2 = fall2Arr;
-      const fall3 = fall3Arr;
+      const fall1 = fall1Arr.array;
+      const fall2 = fall2Arr.array;
+      const fall3 = fall3Arr.array;
       items = fall1.length ? fall1 : (fall2.length ? fall2 : fall3);
     }
 

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -1,7 +1,6 @@
 // File: pages/api/history-roi.js
 import { computeROI } from "../../lib/history-utils";
 import { normalizeMarketKey } from "./history";
-import { jsonMeta, arrayMeta } from "../../lib/kv-meta";
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 export const config = { api: { bodyParser: false } };
@@ -81,21 +80,21 @@ async function loadDay(ymd, trace, wantDebug = false) {
 
   const histValue = toJson(rawHist);
   const histItems = arrFromAny(histValue);
-  let items = filterAllowed(histItems);
+  let items = filterAllowed(histItems.array);
 
   const combKey = `vb:day:${ymd}:combined`;
   const { raw: rawComb } = await kvGETraw(combKey, trace);
   const combValue = toJson(rawComb);
   const combItems = arrFromAny(combValue);
   if (!items.length) {
-    items = filterAllowed(combItems);
+    items = filterAllowed(combItems.array);
   }
   let meta = null;
   if (wantDebug) {
-    const histJsonMeta = jsonMeta(rawHist, histValue);
-    const histArrayMeta = arrayMeta(histValue, histItems, histJsonMeta);
-    const combJsonMeta = jsonMeta(rawComb, combValue);
-    const combArrayMeta = arrayMeta(combValue, combItems, combJsonMeta);
+    const histJsonMeta = { ...histValue.meta };
+    const histArrayMeta = { ...histItems.meta };
+    const combJsonMeta = { ...combValue.meta };
+    const combArrayMeta = { ...combItems.meta };
     meta = {
       hist: { json: histJsonMeta, array: histArrayMeta },
       combined: { json: combJsonMeta, array: combArrayMeta },

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -1,6 +1,5 @@
 // File: pages/api/history.js
 import { computeROI } from "../../lib/history-utils";
-import { jsonMeta, arrayMeta } from "../../lib/kv-meta";
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 export const config = { api: { bodyParser: false } };
@@ -94,7 +93,7 @@ async function loadHistoryForDay(ymd, trace, wantDebug = false) {
 
   const histValue = toJson(rawHist);
   const histItems = arrFromAny(histValue);
-  let items = filterAllowed(histItems);
+  let items = filterAllowed(histItems.array);
 
   // Fallback: combined list
   const combKey = `vb:day:${ymd}:combined`;
@@ -102,15 +101,15 @@ async function loadHistoryForDay(ymd, trace, wantDebug = false) {
   const combValue = toJson(rawComb);
   const combItems = arrFromAny(combValue);
   if (!items.length) {
-    items = filterAllowed(combItems);
+    items = filterAllowed(combItems.array);
   }
 
   let meta = null;
   if (wantDebug) {
-    const histJsonMeta = jsonMeta(rawHist, histValue);
-    const histArrayMeta = arrayMeta(histValue, histItems, histJsonMeta);
-    const combJsonMeta = jsonMeta(rawComb, combValue);
-    const combArrayMeta = arrayMeta(combValue, combItems, combJsonMeta);
+    const histJsonMeta = { ...histValue.meta };
+    const histArrayMeta = { ...histItems.meta };
+    const combJsonMeta = { ...combValue.meta };
+    const combArrayMeta = { ...combItems.meta };
     meta = {
       hist: { json: histJsonMeta, array: histArrayMeta },
       combined: { json: combJsonMeta, array: combArrayMeta },


### PR DESCRIPTION
## Summary
- wrap KV JSON reads with value+meta objects that preserve parse results, type info, and array source metadata
- update API consumers to use the new structures and clone metadata for debug traces

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd83eaac1c83228e74d1288336113b