### PR TITLE
Fix API Football KV helpers

### DIFF
--- a/lib/sources/apiFootball.js
+++ b/lib/sources/apiFootball.js
@@ -105,12 +105,60 @@ async function afxKvGet(key) {
       cache: "no-store",
     });
     if (!r.ok) return null;
-    const t = await r.text();
-    try {
-      return JSON.parse(t);
-    } catch {
-      return null;
+    const ct = r.headers.get("content-type") || "";
+    let body = null;
+    if (ct.includes("application/json")) {
+      body = await r.json().catch(() => null);
+    } else {
+      const text = await r.text();
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
     }
+    if (body == null) return null;
+
+    let value;
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      if (Object.prototype.hasOwnProperty.call(body, "result")) {
+        value = body.result;
+      } else if (Object.prototype.hasOwnProperty.call(body, "value")) {
+        value = body.value;
+      } else {
+        value = body;
+      }
+    } else {
+      value = body;
+    }
+
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      if (
+        Object.prototype.hasOwnProperty.call(value, "value") &&
+        typeof value.value === "string"
+      ) {
+        const inner = value.value.trim();
+        if (!inner) return null;
+        try {
+          return JSON.parse(inner);
+        } catch {
+          return value.value;
+        }
+      }
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return value;
+      }
+    }
+
+    return value ?? null;
   } catch {
     return null;
   }
@@ -125,7 +173,7 @@ async function afxKvSet(key, value) {
         Authorization: `Bearer ${AFX_KV_TOKEN_RW}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(value),
+      body: JSON.stringify({ value: JSON.stringify(value) }),
     });
     return r.ok;
   } catch {


### PR DESCRIPTION
## Summary
- parse Upstash/Vercel KV responses so cache entries and counters are decoded correctly
- send serialized payloads inside `{ value: ... }` when writing to KV to match the platform API

## Testing
- npm test
- node - <<'NODE' ... (simulated refresh-odds cron to confirm cache hits and budget decrements)


------
https://chatgpt.com/codex/tasks/task_e_68cea9dbd7f88322971304026164d723