### PR TITLE
Make learning workflow schedule timezone aware

### DIFF
--- a/.github/workflows/learning.yml
+++ b/.github/workflows/learning.yml
@@ -6,12 +6,15 @@ on:
     branches:
       - main
   schedule:
-    # 00:00 Europe/Belgrade  ≈ 22:00 UTC (tokom CEST)
-    - cron: '0 22 * * *'
-    # 10:00 Europe/Belgrade ≈ 08:00 UTC
-    - cron: '0 8 * * *'
-    # 15:00 Europe/Belgrade ≈ 13:00 UTC
-    - cron: '0 13 * * *'
+    # 00:00 Europe/Belgrade
+    - cron: '0 0 * * *'
+      timezone: 'Europe/Belgrade'
+    # 10:00 Europe/Belgrade
+    - cron: '0 10 * * *'
+      timezone: 'Europe/Belgrade'
+    # 15:00 Europe/Belgrade
+    - cron: '0 15 * * *'
+      timezone: 'Europe/Belgrade'
 
 concurrency:
   group: snapshots-${{ github.ref }}


### PR DESCRIPTION
## Summary
- update the scheduled triggers in the learning workflow to use timezone-aware cron definitions for Europe/Belgrade
- ensure the jobs run at 00:00, 10:00, and 15:00 local time year-round without DST offsets

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ceacbdf648832284ba67213c93780c