### PR TITLE
Increase AFX daily budget default

### DIFF
--- a/lib/sources/apiFootball.js
+++ b/lib/sources/apiFootball.js
@@ -67,7 +67,7 @@ module.exports = {
 // ✓ Ako KV nije podešen, radi bez keša i bez budžeta (graceful fallback)
 // ✓ Ne koristi RapidAPI header, samo zvanični x-apisports-key
 
-const AFX_DAILY_BUDGET_DEFAULT = 5000; // cilj ~5k/dan
+const AFX_DAILY_BUDGET_DEFAULT = 6000; // cilj ~6k/dan
 const AFX_TZ = "Europe/Belgrade";
 const AFX_API_BASE_DEFAULT = "https://v3.football.api-sports.io";
 


### PR DESCRIPTION
## Summary
- raise the AFX daily budget default to 6000 so the comment and implementation stay aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceaeb1e40c83229d449df800bb5e94