### PR TITLE
Restore hadFull optional chaining

### DIFF
--- a/pages/api/cron/refresh-odds.js
+++ b/pages/api/cron/refresh-odds.js
@@ -223,7 +223,7 @@ export default async function handler(req, res){
     const lastKey  = `vb:last-odds:${slot}`;
     const union = kvToItems(await kvGET(unionKey, trace));
     const full  = kvToItems(await kvGET(fullKey,  trace));
-    const hadFull = full.items.length > 0;
+    const hadFull = (full?.items?.length ?? 0) > 0;
 
     const items = (hadFull ? full.items : union.items).slice();
 


### PR DESCRIPTION
## Summary
- use optional chaining when checking if the full snapshot already contains items
- keep selecting between full and union lists based on the hadFull flag

## Testing
- `npm test -- --runTestsByPath __tests__/learning-eval.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cece821a9083229baa964b03c31b33