### PR TITLE
Handle missing API key in scheduled workflows

### DIFF
--- a/.github/workflows/odds-watcher.yml
+++ b/.github/workflows/odds-watcher.yml
@@ -18,10 +18,28 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
+    env:
+      API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}
     permissions:
       contents: read
     timeout-minutes: 7
     steps:
+      - name: Check API key
+        id: api_key
+        env:
+          SECRET_NAME: API_FOOTBALL_KEY
+          API_KEY: ${{ env.API_FOOTBALL_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${API_KEY:-}" ]; then
+            echo "::notice::Skipping API-dependent steps because secret ${SECRET_NAME} is not configured."
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "API key from secret ${SECRET_NAME} is available; continuing with API-dependent steps."
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Compute slot and minute (Europe/Belgrade)
         id: ctx
         run: |
@@ -53,6 +71,7 @@ jobs:
 
       - name: Ensure KV has items (self-warm if empty)
         id: warm
+        if: steps.api_key.outputs.has_key == 'true'
         run: |
           set -euo pipefail
           BASE="${{ steps.base.outputs.base }}"
@@ -84,6 +103,7 @@ jobs:
 
       - name: Guard rebuild / refresh
         id: guard
+        if: steps.api_key.outputs.has_key == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           MINUTE: ${{ steps.ctx.outputs.minute }}
@@ -144,7 +164,7 @@ jobs:
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
       - name: Rebuild KV (guarded)
-        if: steps.guard.outputs.should_run == 'true'
+        if: steps.guard.outputs.should_run == 'true' && steps.api_key.outputs.has_key == 'true'
         run: |
           set -euo pipefail
           BASE="${{ steps.base.outputs.base }}"
@@ -158,7 +178,7 @@ jobs:
             "$BASE/api/cron/rebuild?slot=$SLOT" || true
 
       - name: Refresh odds for current slot (guarded)
-        if: steps.guard.outputs.should_run == 'true'
+        if: steps.guard.outputs.should_run == 'true' && steps.api_key.outputs.has_key == 'true'
         run: |
           set -euo pipefail
           BASE="${{ steps.base.outputs.base }}"
@@ -172,4 +192,10 @@ jobs:
             "$BASE/api/cron/refresh-odds?slot=$SLOT&force=1" || true
 
       - name: Done
-        run: echo "Done."
+        shell: bash
+        run: |
+          if [ "${{ steps.api_key.outputs.has_key }}" = "true" ]; then
+            echo "Done."
+          else
+            echo "Done. API-dependent steps were skipped because secret API_FOOTBALL_KEY is not configured."
+          fi

--- a/.github/workflows/snapshots-fixed.yml
+++ b/.github/workflows/snapshots-fixed.yml
@@ -45,8 +45,25 @@ jobs:
       # Default guard window (minutes) for slot detection; override via repo variable
       # `SNAPSHOT_GUARD_MINUTES` to tune without editing the workflow.
       FREEZE_MINUTES: ${{ vars.SNAPSHOT_GUARD_MINUTES || '75' }}
+      API_FOOTBALL_KEY: ${{ secrets.API_FOOTBALL_KEY }}
 
     steps:
+      - name: Check API key
+        id: api_key
+        env:
+          SECRET_NAME: API_FOOTBALL_KEY
+          API_KEY: ${{ env.API_FOOTBALL_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${API_KEY:-}" ]; then
+            echo "::notice::Skipping API-dependent steps because secret ${SECRET_NAME} is not configured."
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "API key from secret ${SECRET_NAME} is available; continuing with API-dependent steps."
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Ensure jq is available
         shell: bash
         run: |
@@ -143,7 +160,7 @@ jobs:
 
       # 1) Rebuild (pass 1)
       - name: Rebuild snapshot (pass 1)
-        if: steps.ctx.outputs.run == 'true'
+        if: steps.ctx.outputs.run == 'true' && steps.api_key.outputs.has_key == 'true'
         env:
           BASE: ${{ steps.ctx.outputs.base }}
           SLOT: ${{ steps.ctx.outputs.slot }}
@@ -156,7 +173,7 @@ jobs:
 
       # 2) Refresh odds (kratko, batch ×2)
       - name: Refresh odds (batch, force)
-        if: steps.ctx.outputs.run == 'true'
+        if: steps.ctx.outputs.run == 'true' && steps.api_key.outputs.has_key == 'true'
         env:
           BASE: ${{ steps.ctx.outputs.base }}
           SLOT: ${{ steps.ctx.outputs.slot }}
@@ -171,7 +188,7 @@ jobs:
 
       # 3) Rebuild (final)
       - name: Rebuild snapshot (final)
-        if: steps.ctx.outputs.run == 'true'
+        if: steps.ctx.outputs.run == 'true' && steps.api_key.outputs.has_key == 'true'
         env:
           BASE: ${{ steps.ctx.outputs.base }}
           SLOT: ${{ steps.ctx.outputs.slot }}
@@ -184,7 +201,7 @@ jobs:
 
       # 4) Insights (grupiše specijale i zamrzava po slotu)
       - name: Build insights (tickets)
-        if: steps.ctx.outputs.run == 'true'
+        if: steps.ctx.outputs.run == 'true' && steps.api_key.outputs.has_key == 'true'
         env:
           BASE: ${{ steps.ctx.outputs.base }}
           SLOT: ${{ steps.ctx.outputs.slot }}
@@ -196,7 +213,7 @@ jobs:
 
       # 5) Apply learning
       - name: Apply learning
-        if: steps.ctx.outputs.run == 'true'
+        if: steps.ctx.outputs.run == 'true' && steps.api_key.outputs.has_key == 'true'
         env:
           BASE: ${{ steps.ctx.outputs.base }}
           SLOT: ${{ steps.ctx.outputs.slot }}
@@ -208,6 +225,7 @@ jobs:
 
       # 6) Sanity check
       - name: Sanity check (locked feed)
+        if: steps.api_key.outputs.has_key == 'true'
         env:
           BASE: ${{ steps.ctx.outputs.base }}
           SLOT: ${{ steps.ctx.outputs.slot }}


### PR DESCRIPTION
## Summary
- expose the API_FOOTBALL_KEY secret in the snapshots workflow, check for it early, and only run API-dependent steps when present
- apply the same API key check pattern to the odds watcher workflow so guarded rebuild/refresh steps skip cleanly when the secret is missing

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d00808f2d883228d53b01a8c5ffc57