### PR TITLE
Add refresh odds smoke workflow

### DIFF
--- a/.github/workflows/refresh-odds-smoke.yml
+++ b/.github/workflows/refresh-odds-smoke.yml
@@ -1,0 +1,31 @@
+name: Refresh odds smoke
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check for conflict markers
+        run: |
+          if git grep -n '<<<<<<<\\|=======\\|>>>>>>>' --; then
+            echo "Conflict markers detected"
+            exit 1
+          fi
+
+      - name: Refresh odds smoke test
+        run: npm run smoke:refresh-odds

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "autoprefixer": "10.4.19",
         "jest": "29.7.0",
+        "jiti": "^2.5.1",
         "postcss": "8.4.39",
         "tailwindcss": "3.4.9"
       },
@@ -3772,13 +3773,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -5177,6 +5178,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {

--- a/package.json
+++ b/package.json
@@ -6,22 +6,24 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest"
+    "test": "jest",
+    "smoke:refresh-odds": "node scripts/refresh-odds-smoke.js"
   },
   "dependencies": {
+    "chart.js": "4.4.4",
+    "chartjs-adapter-date-fns": "3.0.0",
+    "chartjs-plugin-annotation": "3.0.1",
+    "date-fns": "2.30.0",
     "next": "14.2.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "chart.js": "4.4.4",
-    "chartjs-plugin-annotation": "3.0.1",
-    "chartjs-adapter-date-fns": "3.0.0",
-    "date-fns": "2.30.0"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "autoprefixer": "10.4.19",
+    "jest": "29.7.0",
+    "jiti": "^2.5.1",
     "postcss": "8.4.39",
-    "tailwindcss": "3.4.9",
-    "jest": "29.7.0"
+    "tailwindcss": "3.4.9"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/pages/api/cron/refresh-odds.js
+++ b/pages/api/cron/refresh-odds.js
@@ -214,6 +214,7 @@ export default async function handler(req, res){
     if (!apiKey) {
       return res.status(200).json({
         ok:false,
+        reason:"missing API_FOOTBALL_KEY",
         error:"API-Football key missing (tried: APIFOOTBALL_KEY, API_FOOTBALL_KEY, APISPORTS_KEY, APISPORTS_API_KEY, X_APISPORTS_KEY)"
       });
     }

--- a/scripts/refresh-odds-smoke.js
+++ b/scripts/refresh-odds-smoke.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+const { strict: assert } = require("node:assert");
+
+const KEY_ENV_VARS = [
+  "APIFOOTBALL_KEY",
+  "API_FOOTBALL_KEY",
+  "APISPORTS_KEY",
+  "APISPORTS_API_KEY",
+  "X_APISPORTS_KEY",
+  "NEXT_PUBLIC_API_FOOTBALL_KEY",
+];
+
+const KV_ENV_VARS = [
+  "KV_REST_API_URL",
+  "KV_REST_API_TOKEN",
+  "KV_REST_API_READ_ONLY_TOKEN",
+];
+
+const ALL_ENV_VARS = [...new Set([...KEY_ENV_VARS, ...KV_ENV_VARS])];
+
+function setKeyEnv(value) {
+  for (const name of KEY_ENV_VARS) {
+    if (value == null) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+function restoreEnv(snapshot) {
+  for (const [name, value] of Object.entries(snapshot)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+function makeRes() {
+  const res = {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+  return res;
+}
+
+function makeReq(query = {}) {
+  return {
+    method: "GET",
+    headers: {},
+    query,
+  };
+}
+
+async function invoke(handler, { query = {} } = {}) {
+  const req = makeReq(query);
+  const res = makeRes();
+  await handler(req, res);
+  return res.jsonPayload;
+}
+
+async function main() {
+  const savedEnv = Object.fromEntries(ALL_ENV_VARS.map((name) => [name, process.env[name]]));
+
+  let stubCalls = 0;
+  const stubResponse = {
+    response: [
+      {
+        bookmakers: [
+          {
+            bets: [
+              {
+                name: "Match Winner",
+                values: [
+                  { value: "Home", odd: "2.10" },
+                  { value: "Draw", odd: "3.10" },
+                  { value: "Away", odd: "3.50" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const stubExports = {
+    afxOddsByFixture: async () => {
+      stubCalls += 1;
+      return stubResponse;
+    },
+  };
+  stubExports.default = stubExports;
+
+  const apiFootballPath = require.resolve("../lib/sources/apiFootball.js");
+  require.cache[apiFootballPath] = {
+    id: apiFootballPath,
+    filename: apiFootballPath,
+    loaded: true,
+    exports: stubExports,
+  };
+
+  const jiti = require("jiti")(__filename);
+  const handlerModule = jiti("../pages/api/cron/refresh-odds.js");
+  const handler = handlerModule.default || handlerModule;
+
+  const kvBase = "https://kv.example.test";
+  const originalFetch = global.fetch;
+
+  const kvFixturesDoc = {
+    items: [
+      {
+        fixture_id: 4242,
+        league: { name: "UEFA Test League" },
+      },
+    ],
+  };
+
+  function jsonResponse(body, { ok = true, status } = {}) {
+    const httpStatus = status ?? (ok ? 200 : 404);
+    return {
+      ok,
+      status: httpStatus,
+      headers: {
+        get(name) {
+          return name.toLowerCase() === "content-type" ? "application/json" : null;
+        },
+      },
+      async json() {
+        return body;
+      },
+      async text() {
+        return JSON.stringify(body);
+      },
+    };
+  }
+
+  const stubFetch = async (url, init = {}) => {
+    const target = typeof url === "string" ? url : url?.toString?.() || "";
+    if (target.startsWith(kvBase)) {
+      if (target.includes("/get/")) {
+        const key = decodeURIComponent(target.split("/get/")[1] || "");
+        if (key.startsWith("vb:day:")) {
+          return jsonResponse({ result: kvFixturesDoc });
+        }
+        if (key.startsWith("vbl_full:")) {
+          return jsonResponse({ result: { items: [] } });
+        }
+        return jsonResponse({}, { ok: false, status: 404 });
+      }
+      if (target.includes("/set/")) {
+        return jsonResponse({ ok: true });
+      }
+    }
+    if (originalFetch) {
+      return originalFetch(url, init);
+    }
+    throw new Error(`Unhandled fetch URL in smoke test: ${target}`);
+  };
+
+  process.env.KV_REST_API_URL = kvBase;
+  process.env.KV_REST_API_TOKEN = "kv-stub-token";
+  process.env.KV_REST_API_READ_ONLY_TOKEN = "kv-stub-ro";
+
+  try {
+    global.fetch = stubFetch;
+    setKeyEnv(null);
+    const first = await invoke(handler);
+    assert.strictEqual(first.ok, false);
+    assert.strictEqual(first.reason, "missing API_FOOTBALL_KEY");
+
+    setKeyEnv("dummy-key");
+    const second = await invoke(handler);
+    assert.strictEqual(second.ok, true);
+
+    if (stubCalls === 0) {
+      throw new Error("Expected afxOddsByFixture stub to be invoked at least once");
+    }
+  } finally {
+    global.fetch = originalFetch;
+    restoreEnv(savedEnv);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a refresh-odds smoke workflow to CI to install deps, check for conflict markers, and run the new smoke script
- create a node smoke harness that stubs API-Football calls, simulates KV storage, and asserts the handler reports missing API keys
- expose the smoke script through npm and return an explicit reason from the API when the key is missing to match the smoke expectations

## Testing
- npm run smoke:refresh-odds

------
https://chatgpt.com/codex/tasks/task_e_68d0080e045483229b4e4057867d1e97