### PR TITLE
Fix history KV fallback when primary misses

### DIFF
--- a/__tests__/pages/api/history-backend-fallback.test.js
+++ b/__tests__/pages/api/history-backend-fallback.test.js
@@ -1,0 +1,135 @@
+const sampleHistoryPayload = {
+  history: [
+    {
+      fixture_id: "fx-secondary-1",
+      market_key: "h2h",
+      pick: "home",
+      result: "win",
+      price_snapshot: 2.25,
+    },
+  ],
+};
+
+const realFetch = global.fetch;
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+const kvResponseModes = [
+  ["string payloads", (payload) => ({ result: JSON.stringify(payload) })],
+  ["object payloads", (payload) => ({ result: payload })],
+];
+
+describe.each(kvResponseModes)(
+  "API history secondary backend fallback (%s)",
+  (modeLabel, makeEnvelope) => {
+    function mockSecondaryOnly(fetchMock, payload) {
+      const miss = () => ({
+        ok: true,
+        json: async () => ({ result: null }),
+      });
+      fetchMock.mockResolvedValueOnce(miss());
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeEnvelope(payload),
+      });
+      fetchMock.mockResolvedValueOnce(miss());
+      fetchMock.mockResolvedValueOnce(miss());
+    }
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env.HISTORY_ALLOWED_MARKETS = "h2h";
+      process.env.KV_REST_API_URL = "https://primary-kv.example";
+      process.env.KV_REST_API_TOKEN = "primary-token";
+      process.env.UPSTASH_REDIS_REST_URL = "https://secondary-kv.example";
+      process.env.UPSTASH_REDIS_REST_TOKEN = "secondary-token";
+    });
+
+    afterEach(() => {
+      if (realFetch) {
+        global.fetch = realFetch;
+      } else {
+        delete global.fetch;
+      }
+      delete process.env.HISTORY_ALLOWED_MARKETS;
+      delete process.env.KV_REST_API_URL;
+      delete process.env.KV_REST_API_TOKEN;
+      delete process.env.UPSTASH_REDIS_REST_URL;
+      delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    it("returns history stored only in the secondary backend", async () => {
+      const fetchMock = jest.fn();
+      mockSecondaryOnly(fetchMock, sampleHistoryPayload);
+      global.fetch = fetchMock;
+
+      const { default: handler } = require("../../../pages/api/history");
+
+      const req = { query: { ymd: "2024-06-02", debug: "1" } };
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonPayload.count).toBe(1);
+      expect(res.jsonPayload.history.map((e) => e.fixture_id)).toContain(
+        "fx-secondary-1"
+      );
+      expect(res.jsonPayload.debug.trace).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "vercel-kv",
+            hit: false,
+          }),
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "upstash-redis",
+            hit: true,
+          }),
+        ])
+      );
+    });
+
+    it("computes ROI from entries stored only in the secondary backend", async () => {
+      const fetchMock = jest.fn();
+      mockSecondaryOnly(fetchMock, sampleHistoryPayload);
+      global.fetch = fetchMock;
+
+      const { default: handler } = require("../../../pages/api/history-roi");
+
+      const req = { query: { ymd: "2024-06-02", debug: "1" } };
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonPayload.count).toBe(1);
+      expect(res.jsonPayload.roi).toMatchObject({ played: 1, wins: 1 });
+      expect(res.jsonPayload.debug.trace).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "upstash-redis",
+            hit: true,
+          }),
+        ])
+      );
+    });
+  }
+);

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -26,11 +26,13 @@ async function kvGETraw(key, trace) {
       let raw = null;
       if (typeof payload === "string") {
         raw = payload;
-      } else if (payload !== undefined) {
-        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
+      } else if (payload !== undefined && payload !== null) {
+        try { raw = JSON.stringify(payload); } catch { raw = null; }
       }
-      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: typeof raw === "string" });
+      const hit = typeof raw === "string";
+      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit });
       if (!r.ok) continue;
+      if (!hit) continue;
       return { raw, flavor: b.flavor };
     } catch (e) {
       trace && trace.push({ get: key, ok: false, err: String(e?.message || e) });

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -25,11 +25,13 @@ async function kvGETraw(key, trace) {
       let raw = null;
       if (typeof payload === "string") {
         raw = payload;
-      } else if (payload !== undefined) {
-        try { raw = JSON.stringify(payload ?? null); } catch { raw = null; }
+      } else if (payload !== undefined && payload !== null) {
+        try { raw = JSON.stringify(payload); } catch { raw = null; }
       }
-      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit: typeof raw === "string" });
+      const hit = typeof raw === "string";
+      trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit });
       if (!r.ok) continue;
+      if (!hit) continue;
       return { raw, flavor: b.flavor };
     } catch (e) {
       trace && trace.push({ get: key, ok: false, err: String(e?.message || e) });


### PR DESCRIPTION
## Summary
- ensure the history API skips KV backends that return empty payloads
- mirror the fallback handling for the ROI endpoint
- add regression tests that cover secondary-backend-only history data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0f973cd6483229487747e1cbf2fb2