### PR TITLE
Handle cleared KV strings as misses

### DIFF
--- a/__tests__/pages/api/history-backend-fallback.test.js
+++ b/__tests__/pages/api/history-backend-fallback.test.js
@@ -133,3 +133,140 @@ describe.each(kvResponseModes)(
     });
   }
 );
+
+describe("API history placeholder string fallback", () => {
+  const placeholderCases = [
+    ["literal null string", "null"],
+    ["empty quoted string", '""'],
+    ["whitespace only", "   "],
+  ];
+
+  function mockClearedPrimary(fetchMock, placeholder, payload) {
+    const cleared = () => ({
+      ok: true,
+      json: async () => ({ result: placeholder }),
+    });
+    const secondaryHit = () => ({
+      ok: true,
+      json: async () => ({ result: JSON.stringify(payload) }),
+    });
+    fetchMock.mockResolvedValueOnce(cleared());
+    fetchMock.mockResolvedValueOnce(secondaryHit());
+    fetchMock.mockResolvedValueOnce(cleared());
+    fetchMock.mockResolvedValueOnce(secondaryHit());
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.HISTORY_ALLOWED_MARKETS = "h2h";
+    process.env.KV_REST_API_URL = "https://primary-kv.example";
+    process.env.KV_REST_API_TOKEN = "primary-token";
+    process.env.UPSTASH_REDIS_REST_URL = "https://secondary-kv.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "secondary-token";
+  });
+
+  afterEach(() => {
+    if (realFetch) {
+      global.fetch = realFetch;
+    } else {
+      delete global.fetch;
+    }
+    delete process.env.HISTORY_ALLOWED_MARKETS;
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it.each(placeholderCases)(
+    "treats %s as a miss and falls back to the secondary backend for /api/history",
+    async (_label, placeholder) => {
+      const fetchMock = jest.fn();
+      mockClearedPrimary(fetchMock, placeholder, sampleHistoryPayload);
+      global.fetch = fetchMock;
+
+      const { default: handler } = require("../../../pages/api/history");
+
+      const req = { query: { ymd: "2024-06-02", debug: "1" } };
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonPayload.count).toBe(1);
+      expect(res.jsonPayload.history.map((e) => e.fixture_id)).toContain(
+        "fx-secondary-1"
+      );
+      expect(res.jsonPayload.debug.trace).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "vercel-kv",
+            hit: false,
+          }),
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "upstash-redis",
+            hit: true,
+          }),
+          expect.objectContaining({
+            get: "vb:day:2024-06-02:combined",
+            flavor: "vercel-kv",
+            hit: false,
+          }),
+          expect.objectContaining({
+            get: "vb:day:2024-06-02:combined",
+            flavor: "upstash-redis",
+            hit: true,
+          }),
+        ])
+      );
+    }
+  );
+
+  it.each(placeholderCases)(
+    "treats %s as a miss and falls back to the secondary backend for /api/history-roi",
+    async (_label, placeholder) => {
+      const fetchMock = jest.fn();
+      mockClearedPrimary(fetchMock, placeholder, sampleHistoryPayload);
+      global.fetch = fetchMock;
+
+      const { default: handler } = require("../../../pages/api/history-roi");
+
+      const req = { query: { ymd: "2024-06-02", debug: "1" } };
+      const res = createMockRes();
+
+      await handler(req, res);
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(res.statusCode).toBe(200);
+      expect(res.jsonPayload.count).toBe(1);
+      expect(res.jsonPayload.roi).toMatchObject({ played: 1, wins: 1 });
+      expect(res.jsonPayload.debug.trace).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "vercel-kv",
+            hit: false,
+          }),
+          expect.objectContaining({
+            get: "hist:2024-06-02",
+            flavor: "upstash-redis",
+            hit: true,
+          }),
+          expect.objectContaining({
+            get: "vb:day:2024-06-02:combined",
+            flavor: "vercel-kv",
+            hit: false,
+          }),
+          expect.objectContaining({
+            get: "vb:day:2024-06-02:combined",
+            flavor: "upstash-redis",
+            hit: true,
+          }),
+        ])
+      );
+    }
+  );
+});

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -13,6 +13,15 @@ function kvBackends() {
   if (bU && bT) out.push({ flavor: "upstash-redis", url: bU.replace(/\/+$/, ""), tok: bT });
   return out;
 }
+const CLEARED_STRING_MARKERS = new Set(["null", "undefined", "nil", "none"]);
+function looksClearedString(value) {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  const unquoted = trimmed.replace(/^"+|"+$/g, "").trim();
+  if (!unquoted) return true;
+  return CLEARED_STRING_MARKERS.has(unquoted.toLowerCase());
+}
 async function kvGETraw(key, trace) {
   for (const b of kvBackends()) {
     try {
@@ -27,6 +36,9 @@ async function kvGETraw(key, trace) {
         raw = payload;
       } else if (payload !== undefined && payload !== null) {
         try { raw = JSON.stringify(payload); } catch { raw = null; }
+      }
+      if (looksClearedString(raw)) {
+        raw = null;
       }
       const hit = typeof raw === "string";
       trace && trace.push({ get: key, ok: r.ok, flavor: b.flavor, hit });


### PR DESCRIPTION
## Summary
- treat cleared string payloads from KV as cache misses so the history endpoint will try secondary backends
- apply the same placeholder detection to the ROI history endpoint
- extend the backend fallback tests to cover literal `"null"` and other cleared-string responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0fedd633c832292fd66749517b7b0