### PR TITLE
Allow 1x2 market picks by default

### DIFF
--- a/__tests__/pages/api/history-market-fallback.test.js
+++ b/__tests__/pages/api/history-market-fallback.test.js
@@ -78,7 +78,28 @@ describe.each(kvResponseModes)("API history market fallback (%s)", (modeLabel, m
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload.count).toBe(1);
     expect(res.jsonPayload.history.map((e) => e.market)).toContain("1x2");
-    expect(res.jsonPayload.debug.allowed).toEqual(["1x2"]);
+    expect(res.jsonPayload.debug.allowed).toEqual(["h2h"]);
+  });
+
+  it("allows 1x2 entries even when no explicit HISTORY_ALLOWED_MARKETS is set", async () => {
+    const fetchMock = jest.fn();
+    mockKvResponses(fetchMock, sampleHistoryPayload);
+    global.fetch = fetchMock;
+
+    delete process.env.HISTORY_ALLOWED_MARKETS;
+
+    const { default: handler } = require("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-06-01", debug: "1" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.count).toBe(1);
+    expect(res.jsonPayload.history.map((e) => e.market)).toContain("1x2");
+    expect(res.jsonPayload.debug.allowed).toEqual(["h2h"]);
   });
 
   it("includes market fallback entries when computing ROI", async () => {
@@ -97,7 +118,28 @@ describe.each(kvResponseModes)("API history market fallback (%s)", (modeLabel, m
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload.count).toBe(1);
     expect(res.jsonPayload.roi).toMatchObject({ played: 1, wins: 1 });
-    expect(res.jsonPayload.debug.allowed).toEqual(["1x2"]);
+    expect(res.jsonPayload.debug.allowed).toEqual(["h2h"]);
+  });
+
+  it("computes ROI for 1x2 entries using the default allow-list", async () => {
+    const fetchMock = jest.fn();
+    mockKvResponses(fetchMock, sampleHistoryPayload);
+    global.fetch = fetchMock;
+
+    delete process.env.HISTORY_ALLOWED_MARKETS;
+
+    const { default: handler } = require("../../../pages/api/history-roi");
+
+    const req = { query: { ymd: "2024-06-01", debug: "1" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.count).toBe(1);
+    expect(res.jsonPayload.roi).toMatchObject({ played: 1, wins: 1 });
+    expect(res.jsonPayload.debug.allowed).toEqual(["h2h"]);
   });
 });
 

--- a/pages/api/history-roi.js
+++ b/pages/api/history-roi.js
@@ -1,6 +1,6 @@
 // File: pages/api/history-roi.js
 import { computeROI } from "../../lib/history-utils";
-import { normalizeMarketKey } from "./history";
+import { normalizeMarketKey, DEFAULT_MARKET_KEY } from "./history";
 import { arrFromAny, toJson } from "../../lib/kv-read";
 
 export const config = { api: { bodyParser: false } };
@@ -55,8 +55,6 @@ async function kvGETraw(key, trace) {
 
 /* ---------- helpers ---------- */
 const isValidYmd = (s) => /^\d{4}-\d{2}-\d{2}$/.test(String(s || ""));
-
-const DEFAULT_MARKET_KEY = "h2h";
 
 function parseAllowedMarkets(envVal) {
   const raw = String(envVal ?? DEFAULT_MARKET_KEY);

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -55,8 +55,9 @@ async function kvGETraw(key, trace) {
 /* ---------- helpers ---------- */
 const isValidYmd = (s) => /^\d{4}-\d{2}-\d{2}$/.test(String(s || ""));
 
-const DEFAULT_MARKET_KEY = "h2h";
+export const DEFAULT_MARKET_KEY = "h2h";
 const MARKET_KEY_SYNONYMS = {
+  "1x2": "h2h",
   moneyline: "h2h",
   ml: "h2h",
 };


### PR DESCRIPTION
## Summary
- map the 1x2 market key to the h2h synonym so history normalization allows stored picks
- reuse the default market key inside the ROI endpoint so both APIs read identical allow-lists
- extend the history market fallback tests to cover default allow-list behavior for both endpoints

## Testing
- npm test -- history-market-fallback

------
https://chatgpt.com/codex/tasks/task_e_68d135ce9ec48322a1ad253e34aa0991