### PR TITLE
Stabilize combined alias pipeline and KV access

### DIFF
--- a/lib/kv-helpers.js
+++ b/lib/kv-helpers.js
@@ -1,0 +1,314 @@
+// lib/kv-helpers.js
+// Shared helpers for working with Vercel KV and Upstash Redis REST APIs.
+
+const CLEARED_STRING_MARKERS = new Set(["null", "undefined", "nil", "none"]);
+
+function trimKey(key) {
+  return typeof key === "string" ? key.trim() : "";
+}
+
+function sanitizeUrl(url) {
+  return String(url || "").replace(/\/+$/, "");
+}
+
+function kvBackends() {
+  const out = [];
+  const vercelUrlRaw = process.env.KV_REST_API_URL || process.env.KV_URL;
+  const vercelToken = process.env.KV_REST_API_TOKEN || process.env.KV_REST_API_READ_ONLY_TOKEN;
+  const upstashUrlRaw = process.env.UPSTASH_REDIS_REST_URL;
+  const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (vercelUrlRaw && vercelToken) {
+    out.push({ flavor: "vercel-kv", url: sanitizeUrl(vercelUrlRaw), token: vercelToken });
+  }
+  if (upstashUrlRaw && upstashToken) {
+    out.push({ flavor: "upstash-redis", url: sanitizeUrl(upstashUrlRaw), token: upstashToken });
+  }
+  return out;
+}
+
+function looksClearedString(value) {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  const unquoted = trimmed.replace(/^"+|"+$/g, "").trim();
+  if (!unquoted) return true;
+  return CLEARED_STRING_MARKERS.has(unquoted.toLowerCase());
+}
+
+function safeJsonParse(raw) {
+  if (typeof raw !== "string") return raw;
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return raw;
+    }
+  }
+  if (looksClearedString(trimmed)) return null;
+  return raw;
+}
+
+function extractPreferredArrays(payload) {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload;
+  if (typeof payload !== "object") return [];
+
+  const preferredKeys = [
+    "items",
+    "value_bets",
+    "valueBets",
+    "value-bets",
+    "valuebets",
+    "bets",
+    "entries",
+    "picks",
+    "list",
+    "data",
+    "normalized",
+    "result",
+    "models",
+  ];
+
+  for (const key of preferredKeys) {
+    const candidate = payload[key];
+    if (Array.isArray(candidate)) return candidate;
+  }
+
+  for (const key of preferredKeys) {
+    const candidate = payload[key];
+    if (candidate && typeof candidate === "object") {
+      const nested = extractPreferredArrays(candidate);
+      if (Array.isArray(nested) && nested.length) return nested;
+    }
+  }
+
+  for (const value of Object.values(payload)) {
+    if (Array.isArray(value)) return value;
+  }
+
+  for (const value of Object.values(payload)) {
+    if (value && typeof value === "object") {
+      const nested = extractPreferredArrays(value);
+      if (Array.isArray(nested) && nested.length) return nested;
+    }
+  }
+
+  return [];
+}
+
+function extractArray(payload) {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload;
+
+  const queue = [{ node: payload, depth: 0 }];
+  const visited = new Set();
+  const arrays = [];
+  const maxDepth = 6;
+
+  while (queue.length) {
+    const { node, depth } = queue.shift();
+    if (!node || depth > maxDepth) continue;
+    if (typeof node === "string") {
+      const parsed = safeJsonParse(node);
+      if (parsed && typeof parsed === "object") {
+        queue.push({ node: parsed, depth: depth + 1 });
+      }
+      continue;
+    }
+    if (typeof node !== "object") continue;
+    if (visited.has(node)) continue;
+    visited.add(node);
+
+    if (Array.isArray(node)) {
+      arrays.push(node);
+      for (const part of node) {
+        if (part && typeof part === "object") {
+          queue.push({ node: part, depth: depth + 1 });
+        } else if (typeof part === "string") {
+          const parsed = safeJsonParse(part);
+          if (parsed && typeof parsed === "object") {
+            queue.push({ node: parsed, depth: depth + 1 });
+          }
+        }
+      }
+      continue;
+    }
+
+    const keys = Object.keys(node);
+    const numericKeys = keys.filter((k) => /^\d+$/.test(k));
+    if (numericKeys.length && numericKeys.length === keys.length) {
+      const arr = numericKeys
+        .sort((a, b) => Number(a) - Number(b))
+        .map((k) => node[k]);
+      arrays.push(arr);
+      queue.push({ node: arr, depth: depth + 1 });
+      continue;
+    }
+
+    const preferred = extractPreferredArrays(node);
+    if (Array.isArray(preferred) && preferred.length) {
+      arrays.push(preferred);
+    }
+
+    for (const value of Object.values(node)) {
+      if (!value) continue;
+      if (typeof value === "object" || typeof value === "string") {
+        queue.push({ node: value, depth: depth + 1 });
+      }
+    }
+  }
+
+  if (!arrays.length && payload && typeof payload === "object") {
+    const values = Object.values(payload).filter((it) => Array.isArray(it));
+    if (values.length) return values[0];
+  }
+
+  let best = null;
+  let bestScore = -1;
+  for (const arr of arrays) {
+    if (!Array.isArray(arr)) continue;
+    const objects = arr.filter((it) => it && typeof it === "object");
+    const score = objects.length;
+    if (score > bestScore) {
+      bestScore = score;
+      best = arr;
+    }
+  }
+
+  return Array.isArray(best) ? best : [];
+}
+
+function countItems(payload) {
+  const arr = extractArray(payload);
+  return Array.isArray(arr) ? arr.length : 0;
+}
+
+async function readKeyFromBackends(key, options = {}) {
+  const { backends = kvBackends(), parseJson = true, trace } = options;
+  const tried = [];
+  let chosen = null;
+
+  for (const backend of backends) {
+    let result = {
+      key,
+      flavor: backend.flavor,
+      ok: false,
+      status: null,
+      hit: false,
+      count: 0,
+      value: null,
+      error: null,
+      items: [],
+    };
+    try {
+      const url = `${backend.url}/get/${encodeURIComponent(key)}`;
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${backend.token}` },
+        cache: "no-store",
+      });
+      result.ok = res.ok;
+      result.status = res.status;
+      if (res.ok) {
+        const json = await res.json().catch(() => null);
+        const raw = json?.result ?? json?.value ?? null;
+        const value = parseJson ? safeJsonParse(raw) : raw;
+        result.value = value;
+        if (value != null && !looksClearedString(value)) {
+          result.hit = true;
+        }
+        const arr = extractArray(value);
+        if (Array.isArray(arr)) {
+          result.items = arr;
+          result.count = arr.length;
+          if (arr.length > 0) {
+            result.hit = true;
+          }
+        }
+      } else {
+        result.error = `http_${res.status}`;
+      }
+    } catch (err) {
+      result.ok = false;
+      result.error = String(err?.message || err);
+    }
+
+    tried.push(result);
+
+    if (!chosen) {
+      if (result.count > 0) {
+        chosen = result;
+      } else if (result.hit) {
+        chosen = result;
+      }
+    } else if (chosen.count <= 0 && result.count > 0) {
+      chosen = result;
+    }
+  }
+
+  if (trace) {
+    trace.push({ kv_get: { key, tried: tried.map((r) => ({ flavor: r.flavor, ok: r.ok, hit: r.hit, count: r.count, error: r.error })) } });
+  }
+
+  return {
+    key,
+    tried,
+    value: chosen ? chosen.value : null,
+    items: chosen ? chosen.items : [],
+    flavor: chosen ? chosen.flavor : null,
+    hit: Boolean(chosen && chosen.hit),
+    count: chosen ? chosen.count : 0,
+  };
+}
+
+async function writeKeyToBackends(key, value, options = {}) {
+  const { backends = kvBackends(), trace } = options;
+  const saves = [];
+  for (const backend of backends) {
+    try {
+      const bodyValue = typeof value === "string" ? value : JSON.stringify(value);
+      const url = `${backend.url}/set/${encodeURIComponent(key)}`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${backend.token}`,
+        },
+        body: JSON.stringify({ value: bodyValue }),
+      });
+      saves.push({ flavor: backend.flavor, ok: res.ok, status: res.status });
+    } catch (err) {
+      saves.push({ flavor: backend.flavor, ok: false, error: String(err?.message || err) });
+    }
+  }
+  if (trace) {
+    trace.push({ kv: "set", key, saves });
+  }
+  return saves;
+}
+
+async function saveCombinedAlias({ ymd, payload, from = "union", trace }) {
+  const key = `vb:day:${trimKey(ymd)}:combined`;
+  const count = countItems(payload);
+  if (trace) {
+    trace.push({ alias_combined: { from, count } });
+  }
+  if (!trimKey(ymd) || count <= 0) {
+    return { key, count, wrote: false, saves: [] };
+  }
+  const saves = await writeKeyToBackends(key, payload, { trace });
+  const wrote = saves.some((s) => s.ok);
+  return { key, count, wrote, saves };
+}
+
+module.exports = {
+  kvBackends,
+  readKeyFromBackends,
+  writeKeyToBackends,
+  saveCombinedAlias,
+  safeJsonParse,
+  extractArray,
+  countItems,
+  looksClearedString,
+};

--- a/pages/api/cron/backfill-combined.js
+++ b/pages/api/cron/backfill-combined.js
@@ -1,189 +1,118 @@
 // pages/api/cron/backfill-combined.js
 // Backfills vb:day:<YMD>:combined from vb:day:<YMD>:union.
 
-const { CRON_KEY = "" } = process.env;
+const { kvBackends, readKeyFromBackends, saveCombinedAlias } = require("../../../lib/kv-helpers");
 
-function kvBackends() {
-  const out = [];
-  const aUraw = process.env.KV_REST_API_URL || process.env.KV_URL;
-  const aT = process.env.KV_REST_API_TOKEN || process.env.KV_REST_API_READ_ONLY_TOKEN;
-  const bUraw = process.env.UPSTASH_REDIS_REST_URL;
-  const bT = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (aUraw && aT) out.push({ flavor: "vercel-kv", url: aUraw.replace(/\/+$/, ""), tok: aT });
-  if (bUraw && bT) out.push({ flavor: "upstash-redis", url: bUraw.replace(/\/+$/, ""), tok: bT });
-  return out;
-}
-function safeJsonParse(raw) {
-  if (typeof raw !== "string") return raw;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return undefined;
+function summarizeCounts(key, read, backends) {
+  const summary = {};
+  const flavors = new Set();
+  for (const backend of backends || []) {
+    if (backend?.flavor) flavors.add(backend.flavor);
   }
-}
-function extractArray(payload, depth = 0) {
-  if (payload == null || depth > 3) return [];
-  if (Array.isArray(payload)) return payload;
-  if (typeof payload !== "object") return [];
-  const preferredKeys = [
-    "items",
-    "value_bets",
-    "valueBets",
-    "value-bets",
-    "valuebets",
-    "bets",
-    "entries",
-    "picks",
-    "list",
-    "data",
-    "normalized",
-  ];
-  for (const key of preferredKeys) {
-    const candidate = payload[key];
-    if (Array.isArray(candidate)) return candidate;
-  }
-  for (const key of preferredKeys) {
-    const candidate = payload[key];
-    if (candidate && typeof candidate === "object") {
-      const nested = extractArray(candidate, depth + 1);
-      if (nested.length) return nested;
+  if (Array.isArray(read?.tried)) {
+    for (const attempt of read.tried) {
+      const flavor = attempt?.flavor || "unknown";
+      flavors.add(flavor);
     }
+  } else if (read?.flavor) {
+    flavors.add(read.flavor);
   }
-  for (const value of Object.values(payload)) {
-    if (Array.isArray(value)) return value;
+  if (!flavors.size) flavors.add("default");
+  for (const flavor of flavors) {
+    summary[flavor] = 0;
   }
-  for (const value of Object.values(payload)) {
-    if (value && typeof value === "object") {
-      const nested = extractArray(value, depth + 1);
-      if (nested.length) return nested;
+  if (Array.isArray(read?.tried)) {
+    for (const attempt of read.tried) {
+      const flavor = attempt?.flavor || "unknown";
+      const count = Number(attempt?.count || 0);
+      summary[flavor] = count;
     }
+  } else if (read?.flavor) {
+    summary[read.flavor] = Number(read.count || 0);
   }
-  return [];
-}
-async function kvGETFromBackend(key, backend) {
-  try {
-    const u = `${backend.url}/get/${encodeURIComponent(key)}`;
-    const r = await fetch(u, { headers: { Authorization: `Bearer ${backend.tok}` }, cache: "no-store" });
-    if (!r.ok) return { flavor: backend.flavor, items: [] };
-    const j = await r.json().catch(() => null);
-    let v = j?.result ?? j?.value ?? null;
-    if (v == null) return { flavor: backend.flavor, items: [] };
-    const parsed = safeJsonParse(v);
-    if (typeof parsed !== "undefined") v = parsed;
-    const items = extractArray(v);
-    return { flavor: backend.flavor, items };
-  } catch {
-    return { flavor: backend.flavor, items: [] };
-  }
-}
-async function kvSET(key, val, trace = []) {
-  const saves = [];
-  for (const b of kvBackends()) {
-    try {
-      const body = typeof val === "string" ? val : JSON.stringify(val);
-      const u = `${b.url}/set/${encodeURIComponent(key)}`;
-      const r = await fetch(u, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${b.tok}` },
-        body: JSON.stringify({ value: body }),
-      });
-      saves.push({ key, flavor: b.flavor, ok: r.ok });
-    } catch (e) {
-      saves.push({ key, flavor: b.flavor, ok: false, error: String(e?.message || e) });
-    }
-  }
-  trace.push({ kv: "set", key, saves });
-  return saves;
-}
-function checkCronKey(req, expected) {
-  if (!expected) return false;
-  const q = String(req.query.key || "");
-  const h = String(req.headers["x-cron-key"] || "");
-  const auth = String(req.headers["authorization"] || "");
-  if (q && q === expected) return true;
-  if (h && h === expected) return true;
-  if (auth.toLowerCase().startsWith("bearer ") && auth.slice(7) === expected) return true;
-  return false;
+  return summary;
 }
 
-export default async function handler(req, res) {
+function pickUnionPayload(read) {
+  if (!read) return { value: null, flavor: null };
+  const tried = Array.isArray(read.tried) ? read.tried : [];
+  const preferredOrder = ["vercel-kv", "upstash-redis"];
+  for (const flavor of preferredOrder) {
+    const match = tried.find((attempt) => attempt?.flavor === flavor && Number(attempt?.count || 0) > 0 && attempt.value != null);
+    if (match) return { value: match.value, flavor };
+  }
+  if (read.value != null && Number(read.count || 0) > 0) {
+    return { value: read.value, flavor: read.flavor || null };
+  }
+  const fallback = tried.find((attempt) => attempt?.value != null && Number(attempt?.count || 0) > 0);
+  if (fallback) {
+    return { value: fallback.value, flavor: fallback.flavor || null };
+  }
+  return { value: null, flavor: null };
+}
+
+module.exports = async function handler(req, res) {
   try {
-    if (!checkCronKey(req, CRON_KEY)) {
+    const cronKey = String(process.env.CRON_KEY || "").trim();
+    const providedKey = String(req.query?.key || req.body?.key || "").trim();
+    if (!cronKey || !providedKey || providedKey !== cronKey) {
       return res.status(401).json({ ok: false, error: "unauthorized" });
     }
+
     const ymd = String(req.query?.ymd || req.body?.ymd || "").trim();
     if (!ymd) {
       return res.status(400).json({ ok: false, error: "missing_ymd" });
     }
+
     const debugMode = String(req.query?.debug || req.body?.debug || "") === "1";
-    const combinedKey = `vb:day:${ymd}:combined`;
-    const sources = [
-      combinedKey,
-      `vb:day:${ymd}:am`,
-      `vb:day:${ymd}:pm`,
-      `vb:day:${ymd}:late`,
-      `vb:day:${ymd}:union`,
-    ];
-    const collected = [];
-    const perKeyCounts = {};
-    const knownFlavors = ["vercel-kv", "upstash-redis"];
+    const trace = [];
     const backends = kvBackends();
-    for (const key of sources) {
-      perKeyCounts[key] = { "vercel-kv": 0, "upstash-redis": 0 };
-      let chosen = [];
-      for (const backend of backends) {
-        const { flavor, items } = await kvGETFromBackend(key, backend);
-        const count = Array.isArray(items) ? items.length : 0;
-        if (knownFlavors.includes(flavor)) {
-          perKeyCounts[key][flavor] = count;
-        } else {
-          perKeyCounts[key][flavor] = count;
+
+    const combinedKey = `vb:day:${ymd}:combined`;
+    const unionKey = `vb:day:${ymd}:union`;
+
+    const combinedRead = await readKeyFromBackends(combinedKey, { backends, trace });
+    const unionRead = await readKeyFromBackends(unionKey, { backends, trace });
+
+    const perKeyCounts = {
+      [combinedKey]: summarizeCounts(combinedKey, combinedRead, backends),
+      [unionKey]: summarizeCounts(unionKey, unionRead, backends),
+    };
+
+    let wrote = false;
+    let sourceFlavor = null;
+
+    if (Number(combinedRead?.count || 0) <= 0) {
+      const { value: unionPayload, flavor: unionFlavor } = pickUnionPayload(unionRead);
+      sourceFlavor = unionFlavor;
+      if (unionPayload != null) {
+        const result = await saveCombinedAlias({
+          ymd,
+          payload: unionPayload,
+          from: unionFlavor || "union",
+          trace,
+        });
+        wrote = Boolean(result?.count > 0 && result?.wrote);
+        if (wrote) {
+          const refreshed = await readKeyFromBackends(combinedKey, { backends, trace });
+          perKeyCounts[combinedKey] = summarizeCounts(combinedKey, refreshed, backends);
         }
-        if (!chosen.length && count > 0) {
-          chosen = items;
-        }
-      }
-      if (chosen.length) {
-        collected.push(...chosen);
       }
     }
-    const total_before_dedupe = collected.length;
-    const seen = new Set();
-    const merged = [];
-    for (const item of collected) {
-      const rawFixtureId = item?.model?.fixture ?? item?.fixture_id ?? item?.fixture;
-      const dedupeKey = rawFixtureId !== undefined && rawFixtureId !== null ? String(rawFixtureId) : "";
-      if (dedupeKey) {
-        if (seen.has(dedupeKey)) continue;
-        seen.add(dedupeKey);
-      }
-      merged.push(item);
-    }
-    const total_after_dedupe = merged.length;
-    const wrote = total_after_dedupe > 0;
-    if (wrote) {
-      await kvSET(combinedKey, merged);
-    }
+
     const response = {
       ok: true,
       ymd,
       wrote,
-      total_before_dedupe,
-      total_after_dedupe,
+      perKeyCounts,
     };
-    response.totalBeforeDedupe = total_before_dedupe;
-    response.totalAfterDedupe = total_after_dedupe;
+
     if (debugMode) {
-      response.perKeyCounts = perKeyCounts;
-      response.debug = {
-        perKeyCounts,
-        totalBeforeDedupe: total_before_dedupe,
-        totalAfterDedupe: total_after_dedupe,
-        wrote,
-      };
+      response.debug = { trace, sourceFlavor: sourceFlavor || null };
     }
+
     return res.status(200).json(response);
   } catch (err) {
     return res.status(500).json({ ok: false, error: String(err?.message || err) });
   }
-}
+};

--- a/pages/api/kv/get.js
+++ b/pages/api/kv/get.js
@@ -1,0 +1,54 @@
+// pages/api/kv/get.js
+// Lightweight KV inspector that never falls through to Next.js 404.
+
+const { kvBackends, readKeyFromBackends } = require("../../../lib/kv-helpers");
+
+function extractKey(req) {
+  if (req?.query?.key != null) {
+    const raw = Array.isArray(req.query.key) ? req.query.key[0] : req.query.key;
+    return raw != null ? String(raw) : "";
+  }
+  try {
+    const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+    const value = url.searchParams.get("key");
+    return value != null ? String(value) : "";
+  } catch {
+    return "";
+  }
+}
+
+module.exports = async function handler(req, res) {
+  try {
+    res.setHeader("Cache-Control", "no-store");
+    const rawKey = extractKey(req);
+    const key = String(rawKey || "").trim();
+    if (!key) {
+      return res.status(200).json({ ok: true, key: null, hit: false, flavor: null, value: null });
+    }
+
+    const backends = kvBackends();
+    const read = await readKeyFromBackends(key, { backends });
+    const tried = Array.isArray(read?.tried)
+      ? read.tried.map((attempt) => ({
+          flavor: attempt?.flavor || "unknown",
+          ok: Boolean(attempt?.ok),
+          hit: Boolean(attempt?.hit),
+          count: Number(attempt?.count || 0),
+        }))
+      : [];
+
+    const response = {
+      ok: true,
+      key,
+      hit: Boolean(read?.hit),
+      flavor: read?.flavor || null,
+      value: read?.value ?? null,
+    };
+
+    if (tried.length) response.tried = tried;
+
+    return res.status(200).json(response);
+  } catch (err) {
+    return res.status(200).json({ ok: false, error: String(err?.message || err) });
+  }
+};


### PR DESCRIPTION
## Summary
- add shared KV helpers for reading/writing both Vercel KV and Upstash Redis
- ensure cron rebuild persists vb:day:<YMD>:combined via the shared helper and log alias writes
- update apply-learning to fetch across flavors, normalize slot payloads, and dedupe by fixture with highest probability
- rewrite backfill-combined auth/write path and add a resilient /api/kv/get JSON handler

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3df67e2e4832299cbc7351a7ac95f