### PR TITLE
fix(apply-learning): prevent 500 and write hist:* (H2H-only)

### DIFF
--- a/__tests__/pages/api/apply-learning.test.js
+++ b/__tests__/pages/api/apply-learning.test.js
@@ -34,6 +34,13 @@ describe("apply-learning history writer", () => {
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
     fetchMock = jest.fn(async (url, options = {}) => {
       if (url === `https://kv.example/get/${encodeURIComponent(`vb:day:${ymd}:union`)}`) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({}),
+        };
+      }
+      if (url === `https://kv.example/get/${encodeURIComponent(`vb:day:${ymd}:combined`)}`) {
         const payload = {
           items: [
             {
@@ -102,6 +109,7 @@ describe("apply-learning history writer", () => {
     const req = {
       url: `/api/cron/apply-learning?ymd=${encodeURIComponent(ymd)}&debug=1`,
       headers: { host: "example.test", "x-forwarded-proto": "https" },
+      query: { ymd },
     };
     const res = createMockRes();
 


### PR DESCRIPTION
## Summary
- guard /api/cron/apply-learning against missing req.url by resolving ymd from req.query first and logging URL parse errors without crashing
- adjust the smoke test to cover the combined-key fallback path and query-provided ymd so History continues to be written for H2H picks

## Testing
- npm run lint *(script missing)*
- npm run typecheck *(script missing)*
- npm test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51b57c3d483228238af333d5b9554