### PR TITLE
Fix apply-learning cron to return stable responses

### DIFF
--- a/__tests__/pages/api/apply-learning.test.js
+++ b/__tests__/pages/api/apply-learning.test.js
@@ -133,8 +133,10 @@ describe("apply-learning history writer", () => {
     const histDayCall = setCalls.find((call) => call.key === `hist:day:${ymd}`);
     expect(histDayCall).toBeDefined();
     expect(fetchMock).toHaveBeenCalled();
-    expect(res.jsonPayload.trace).toEqual(expect.arrayContaining([
-      expect.objectContaining({ kv: "set", key: `hist:day:${ymd}`, ok: true }),
-    ]));
+    expect(res.jsonPayload.trace).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kv: "set", key: `hist:day:${ymd}`, size: expect.any(Number) }),
+      ])
+    );
   });
 });


### PR DESCRIPTION
## Summary
- update `/api/cron/apply-learning` to always return HTTP 200 with structured trace/error payloads and to log KV reads/writes
- add resilient snapshot loading, enforce H2H filtering, and persist history via `kv.setJSON` with fallbacks for missing data
- adjust the apply-learning smoke test to reflect the new trace output schema

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5235875dc832291120de3333f3699