### PR TITLE
fix(history): relax 1X2/H2H inclusion predicate; accept missing odds fields

### DIFF
--- a/__tests__/pages/api/apply-learning.test.js
+++ b/__tests__/pages/api/apply-learning.test.js
@@ -149,7 +149,7 @@ describe("apply-learning history writer", () => {
     expect(relaxedEntry).toBeDefined();
     expect(relaxedEntry.teams.home.name).toBe("Gamma");
     expect(relaxedEntry.teams.away.name).toBe("Delta");
-    expect(relaxedEntry.market_key.toLowerCase()).toBe("1x2");
+    expect(relaxedEntry.market_key.toLowerCase()).toBe("h2h");
 
     expect(res.jsonPayload.trace).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- relax the history inclusion guard so valid 1X2/H2H picks without optional odds fields are preserved and tracked with detailed drop reasons
- normalize accepted markets to the history `h2h` key while keeping team and league metadata intact
- align the apply-learning test with the new history market key expectation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d550308c488322a11f1a0dce73ad47