### PR TITLE
Adjust history fallbacks and tests

### DIFF
--- a/__tests__/pages/api/history-backend-fallback.test.js
+++ b/__tests__/pages/api/history-backend-fallback.test.js
@@ -45,8 +45,6 @@ describe.each(kvResponseModes)(
         ok: true,
         json: async () => makeEnvelope(payload),
       });
-      fetchMock.mockResolvedValueOnce(miss());
-      fetchMock.mockResolvedValueOnce(miss());
     }
 
     beforeEach(() => {
@@ -83,7 +81,7 @@ describe.each(kvResponseModes)(
 
       await handler(req, res);
 
-      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(res.statusCode).toBe(200);
       expect(res.jsonPayload.count).toBe(1);
       expect(res.jsonPayload.history.map((e) => e.fixture_id)).toContain(
@@ -152,8 +150,6 @@ describe("API history placeholder string fallback", () => {
     });
     fetchMock.mockResolvedValueOnce(cleared());
     fetchMock.mockResolvedValueOnce(secondaryHit());
-    fetchMock.mockResolvedValueOnce(cleared());
-    fetchMock.mockResolvedValueOnce(secondaryHit());
   }
 
   beforeEach(() => {
@@ -192,7 +188,7 @@ describe("API history placeholder string fallback", () => {
 
       await handler(req, res);
 
-      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(res.statusCode).toBe(200);
       expect(res.jsonPayload.count).toBe(1);
       expect(res.jsonPayload.history.map((e) => e.fixture_id)).toContain(
@@ -207,16 +203,6 @@ describe("API history placeholder string fallback", () => {
           }),
           expect.objectContaining({
             get: "hist:2024-06-02",
-            flavor: "upstash-redis",
-            hit: true,
-          }),
-          expect.objectContaining({
-            get: "vb:day:2024-06-02:combined",
-            flavor: "vercel-kv",
-            hit: false,
-          }),
-          expect.objectContaining({
-            get: "vb:day:2024-06-02:combined",
             flavor: "upstash-redis",
             hit: true,
           }),
@@ -252,16 +238,6 @@ describe("API history placeholder string fallback", () => {
           }),
           expect.objectContaining({
             get: "hist:2024-06-02",
-            flavor: "upstash-redis",
-            hit: true,
-          }),
-          expect.objectContaining({
-            get: "vb:day:2024-06-02:combined",
-            flavor: "vercel-kv",
-            hit: false,
-          }),
-          expect.objectContaining({
-            get: "vb:day:2024-06-02:combined",
             flavor: "upstash-redis",
             hit: true,
           }),

--- a/__tests__/pages/api/history-market-fallback.test.js
+++ b/__tests__/pages/api/history-market-fallback.test.js
@@ -74,7 +74,7 @@ describe.each(kvResponseModes)("API history market fallback (%s)", (modeLabel, m
 
     await handler(req, res);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload.count).toBe(1);
     expect(res.jsonPayload.history.map((e) => e.market)).toContain("1x2");
@@ -95,7 +95,7 @@ describe.each(kvResponseModes)("API history market fallback (%s)", (modeLabel, m
 
     await handler(req, res);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload.count).toBe(1);
     expect(res.jsonPayload.history.map((e) => e.market)).toContain("1x2");

--- a/__tests__/pages/api/history-normalization.test.js
+++ b/__tests__/pages/api/history-normalization.test.js
@@ -88,7 +88,7 @@ describe.each(kvResponseModes)("API history market normalization (%s)", (modeLab
 
     await handler(req, res);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload.history).toHaveLength(2);
     expect(res.jsonPayload.history.map((e) => e.market_key)).toEqual(

--- a/__tests__/pages/api/history.test.js
+++ b/__tests__/pages/api/history.test.js
@@ -1,0 +1,179 @@
+const sampleHistoryPayload = {
+  history: [
+    {
+      fixture_id: "fx-histday-1",
+      market_key: "h2h",
+      pick: "home",
+      result: "win",
+      price_snapshot: 1.9,
+    },
+  ],
+};
+
+const combinedHistoryPayload = {
+  history: [
+    {
+      fixture_id: "fx-combined-1",
+      market_key: "h2h",
+      pick: "away",
+      result: "win",
+      price_snapshot: 2.4,
+    },
+  ],
+};
+
+const realFetch = global.fetch;
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+describe("API history day loaders", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.HISTORY_ALLOWED_MARKETS = "h2h";
+    process.env.KV_REST_API_URL = "https://primary-kv.example";
+    process.env.KV_REST_API_TOKEN = "primary-token";
+    process.env.UPSTASH_REDIS_REST_URL = "https://secondary-kv.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "secondary-token";
+  });
+
+  afterEach(() => {
+    if (realFetch) {
+      global.fetch = realFetch;
+    } else {
+      delete global.fetch;
+    }
+    delete process.env.HISTORY_ALLOWED_MARKETS;
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it("falls back to hist:day after hist misses", async () => {
+    const miss = () => ({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+    const dayHit = () => ({
+      ok: true,
+      json: async () => ({ result: JSON.stringify(sampleHistoryPayload) }),
+    });
+    const fetchMock = jest.fn();
+    fetchMock.mockResolvedValueOnce(miss()); // hist primary
+    fetchMock.mockResolvedValueOnce(miss()); // hist secondary
+    fetchMock.mockResolvedValueOnce(miss()); // hist_day primary
+    fetchMock.mockResolvedValueOnce(dayHit()); // hist_day secondary
+    global.fetch = fetchMock;
+
+    const { default: handler } = require("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-06-02", debug: "1" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const traceGets = res.jsonPayload.debug.trace
+      .filter((entry) => entry.get)
+      .map((entry) => entry.get);
+    expect(traceGets).toEqual([
+      "hist:2024-06-02",
+      "hist:2024-06-02",
+      "hist:day:2024-06-02",
+      "hist:day:2024-06-02",
+    ]);
+    expect(res.jsonPayload.source["2024-06-02"].used).toBe("hist_day");
+    expect(res.jsonPayload.history.map((e) => e.fixture_id)).toContain(
+      "fx-histday-1"
+    );
+  });
+
+  it("skips combined fallback when debug is disabled", async () => {
+    const miss = () => ({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+    const fetchMock = jest.fn();
+    fetchMock.mockResolvedValueOnce(miss()); // hist primary
+    fetchMock.mockResolvedValueOnce(miss()); // hist secondary
+    fetchMock.mockResolvedValueOnce(miss()); // hist_day primary
+    fetchMock.mockResolvedValueOnce(miss()); // hist_day secondary
+    global.fetch = fetchMock;
+
+    const { default: handler } = require("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-06-03" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const traceGets = res.jsonPayload.debug.trace
+      .filter((entry) => entry.get)
+      .map((entry) => entry.get);
+    expect(traceGets).toEqual([
+      "hist:2024-06-03",
+      "hist:2024-06-03",
+      "hist:day:2024-06-03",
+      "hist:day:2024-06-03",
+    ]);
+    expect(res.jsonPayload.source["2024-06-03"].combined).toBe(false);
+    expect(res.jsonPayload.source["2024-06-03"].used).toBe("hist_day");
+  });
+
+  it("uses combined fallback only when debug is enabled", async () => {
+    const miss = () => ({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+    const combinedHit = () => ({
+      ok: true,
+      json: async () => ({ result: JSON.stringify(combinedHistoryPayload) }),
+    });
+    const fetchMock = jest.fn();
+    fetchMock.mockResolvedValueOnce(miss()); // hist primary
+    fetchMock.mockResolvedValueOnce(miss()); // hist secondary
+    fetchMock.mockResolvedValueOnce(miss()); // hist_day primary
+    fetchMock.mockResolvedValueOnce(miss()); // hist_day secondary
+    fetchMock.mockResolvedValueOnce(miss()); // combined primary
+    fetchMock.mockResolvedValueOnce(combinedHit()); // combined secondary
+    global.fetch = fetchMock;
+
+    const { default: handler } = require("../../../pages/api/history");
+
+    const req = { query: { ymd: "2024-06-04", debug: "1" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    const traceGets = res.jsonPayload.debug.trace
+      .filter((entry) => entry.get)
+      .map((entry) => entry.get);
+    expect(traceGets).toEqual([
+      "hist:2024-06-04",
+      "hist:2024-06-04",
+      "hist:day:2024-06-04",
+      "hist:day:2024-06-04",
+      "vb:day:2024-06-04:combined",
+      "vb:day:2024-06-04:combined",
+    ]);
+    expect(res.jsonPayload.source["2024-06-04"].used).toBe("combined");
+    expect(res.jsonPayload.history.map((e) => e.fixture_id)).toContain(
+      "fx-combined-1"
+    );
+  });
+});

--- a/pages/api/history.js
+++ b/pages/api/history.js
@@ -212,26 +212,26 @@ function filterAllowed(arr) {
 }
 
 async function loadHistoryForDay(ymd, trace, wantDebug = false) {
+  const histKey = `hist:${ymd}`;
+  const { raw: histRespRaw } = await kvGETraw(histKey, trace);
+
+  let sourceUsed = "hist";
+  let arr = parseHistPayload(histRespRaw);
+
   const histDayKey = `hist:day:${ymd}`;
-  const { raw: rawHistDay } = await kvGETraw(histDayKey, trace, `hist:${ymd}`);
-
-  let sourceUsed = "hist_day";
-  let arr = parseHistPayload(rawHistDay);
-  const beforeHistDay = Array.isArray(arr) ? arr.length : 0;
-
-  let histRespRaw = null;
-  if (beforeHistDay === 0) {
-    const { raw } = await kvGETraw(`hist:${ymd}`, trace);
-    histRespRaw = raw;
-    const fromHist = parseHistPayload(raw);
-    if (fromHist.length > 0) {
-      arr = fromHist;
-      sourceUsed = "hist";
+  let rawHistDay = null;
+  if ((Array.isArray(arr) ? arr.length : 0) === 0) {
+    sourceUsed = "hist_day";
+    const resp = await kvGETraw(histDayKey, trace);
+    rawHistDay = resp.raw;
+    const fromHistDay = parseHistPayload(rawHistDay);
+    if (fromHistDay.length > 0) {
+      arr = fromHistDay;
     }
   }
 
   let combRespRaw = null;
-  if ((Array.isArray(arr) ? arr.length : 0) === 0) {
+  if (wantDebug && (Array.isArray(arr) ? arr.length : 0) === 0) {
     const { raw } = await kvGETraw(`vb:day:${ymd}:combined`, trace);
     combRespRaw = raw;
     const fromCombined = parseHistPayload(raw);


### PR DESCRIPTION
## Summary
- update the history day loader to prefer the `hist:<ymd>` key, fall back to `hist:day:<ymd>`, and only hit the combined key when debug mode requests it
- update and extend the API history tests to cover the new lookup order, hist-day fallback, and debug-gated combined fallback behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d64d5fc48c8322966fb6afbfd59d81