### PR TITLE
Add tests for new history payload formats

### DIFF
--- a/__tests__/pages/api/apply-learning.test.js
+++ b/__tests__/pages/api/apply-learning.test.js
@@ -206,7 +206,12 @@ describe("apply-learning history writer", () => {
     expect(fetchMock).toHaveBeenCalled();
     expect(res.jsonPayload.trace).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ kv: "set", key: `hist:day:${ymd}`, size: expect.any(Number) }),
+        expect.objectContaining({ kv: "set", key: `hist:${ymd}`, size: parsedHist.length, ok: true }),
+      ])
+    );
+    expect(res.jsonPayload.trace).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kv: "set", key: `hist:day:${ymd}`, size: parsedHist.length, ok: true }),
       ])
     );
   });


### PR DESCRIPTION
## Summary
- assert that the apply-learning writer trace records kv set operations for both hist keys
- cover the history endpoint when KV returns plain arrays versus wrapped history payloads

## Testing
- npm test -- __tests__/pages/api/apply-learning.test.js __tests__/pages/api/history.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d65e4db42c8322ac6134b6960040e8