### PR TITLE
Infer 1x2 markets when selection implies H2H

### DIFF
--- a/pages/api/cron/apply-learning.impl.js
+++ b/pages/api/cron/apply-learning.impl.js
@@ -1236,6 +1236,7 @@ function enforceHistoryRequirements(items = [], trace) {
     noTeams: 0,
     noSelection: 0,
     invalid: 0,
+    assumedMarket: 0,
   };
 
   for (const original of items || []) {
@@ -1271,6 +1272,17 @@ function enforceHistoryRequirements(items = [], trace) {
         if (candidate.trim().toLowerCase() === "1x2" && !explicitKnown) {
           has1x2 = true;
           break;
+        }
+      }
+    }
+
+    if (!has1x2) {
+      const normalizedSelection = normalizeHistorySelection(original);
+      if (normalizedSelection && ["home", "away", "draw"].includes(normalizedSelection)) {
+        const hasTeams = Boolean(extractTeamMeta(original, "home")) && Boolean(extractTeamMeta(original, "away"));
+        if (isLikelyH2H(original) || hasTeams) {
+          has1x2 = true;
+          reasons.assumedMarket += 1;
         }
       }
     }


### PR DESCRIPTION
## Summary
- allow enforceHistoryRequirements to infer 1x2 eligibility when selections and metadata imply a head-to-head market
- surface the new assumedMarket reason in history trace output
- extend API tests to cover implicit H2H cases and ensure history writes remain arrays

## Testing
- npm test -- apply-learning

------
https://chatgpt.com/codex/tasks/task_e_68d664bb2bf0832295989a4590c053c9