### PR TITLE
Add cron scheduler orchestrator and integration test

### DIFF
--- a/__tests__/pages/api/cron-scheduler.test.js
+++ b/__tests__/pages/api/cron-scheduler.test.js
@@ -1,0 +1,98 @@
+const realFetch = global.fetch;
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    jsonPayload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+describe("cron scheduler orchestrator", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    global.fetch = realFetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it("invokes rebuild, refresh-odds, apply-learning in order with identical params", async () => {
+    const calls = [];
+    global.fetch = jest.fn(async (url) => {
+      calls.push(url);
+      const { pathname, searchParams } = new URL(url);
+      const sharedResponse = {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ ok: true, step: pathname.split("/").pop() }),
+      };
+
+      if (pathname === "/api/cron/rebuild") {
+        expect(searchParams.get("ymd")).toBe("2024-07-01");
+        expect(searchParams.get("slot")).toBe("am");
+        expect(searchParams.get("extra")).toBe("1");
+        return sharedResponse;
+      }
+
+      if (pathname === "/api/cron/refresh-odds") {
+        expect(searchParams.get("ymd")).toBe("2024-07-01");
+        expect(searchParams.get("slot")).toBe("am");
+        expect(searchParams.get("extra")).toBe("1");
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ ok: true, trace: [], updated: 0 }),
+        };
+      }
+
+      if (pathname === "/api/cron/apply-learning") {
+        expect(searchParams.get("ymd")).toBe("2024-07-01");
+        expect(searchParams.get("slot")).toBe("am");
+        expect(searchParams.get("extra")).toBe("1");
+        return sharedResponse;
+      }
+
+      throw new Error(`unexpected fetch call: ${url}`);
+    });
+
+    const { default: handler } = require("../../../pages/api/cron/scheduler.js");
+
+    const req = {
+      query: { ymd: "2024-07-01", slot: "am", extra: "1" },
+      headers: { host: "example.com", "x-forwarded-proto": "https" },
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(calls.map((url) => new URL(url).pathname)).toEqual([
+      "/api/cron/rebuild",
+      "/api/cron/refresh-odds",
+      "/api/cron/apply-learning",
+    ]);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload?.notes).toEqual([
+      expect.objectContaining({ step: "refresh-odds", note: "no_updates" }),
+    ]);
+    expect(res.jsonPayload?.steps).toHaveLength(3);
+    for (const step of res.jsonPayload.steps) {
+      expect(step?.body?.ok).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replace the cron scheduler with an orchestrator that resolves the request slot and date, forwards identical query parameters to rebuild/refresh/apply, and captures each response including no-update notes
- add an integration test that stubs fetch to ensure the orchestrator calls the three cron routes sequentially with the same parameters and surfaces the refresh-odds no-update note

## Testing
- npm test -- __tests__/pages/api/cron-scheduler.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d664bcb2b48322a1d703f48d5b4097