### PR TITLE
Add coverage and metadata handling for KV inspector endpoint

### DIFF
--- a/__tests__/pages/api/kv-get.test.js
+++ b/__tests__/pages/api/kv-get.test.js
@@ -1,0 +1,156 @@
+jest.mock("../../../lib/kv-helpers", () => ({
+  kvBackends: jest.fn(() => []),
+  readKeyFromBackends: jest.fn(),
+}));
+
+const { kvBackends, readKeyFromBackends } = require("../../../lib/kv-helpers");
+const handler = require("../../../pages/api/kv/get");
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    jsonPayload: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return this;
+    },
+  };
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.resetAllMocks();
+});
+
+describe("API /api/kv/get", () => {
+  it("rejects non-GET requests with 405", async () => {
+    const req = { method: "POST", query: { key: "vb:test" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(kvBackends).not.toHaveBeenCalled();
+    expect(readKeyFromBackends).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(405);
+    expect(res.jsonPayload).toEqual({ ok: false, error: "method_not_allowed" });
+    expect(res.headers.Allow).toBe("GET");
+  });
+
+  it("requires a key and returns 400 JSON error when missing", async () => {
+    const req = { method: "GET", query: {} };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(kvBackends).not.toHaveBeenCalled();
+    expect(readKeyFromBackends).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonPayload).toEqual({ ok: false, error: "missing_key" });
+  });
+
+  it("returns a miss envelope with null raw values", async () => {
+    kvBackends.mockReturnValueOnce([{ flavor: "vercel-kv" }]);
+    readKeyFromBackends.mockResolvedValueOnce({
+      value: null,
+      hit: false,
+      flavor: null,
+      tried: [
+        { flavor: "vercel-kv", ok: true, hit: false, count: 0 },
+        { flavor: "upstash-redis", ok: false, hit: false, count: 0 },
+      ],
+    });
+
+    const req = { method: "GET", query: { key: "vb:missing" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(kvBackends).toHaveBeenCalledTimes(1);
+    expect(readKeyFromBackends).toHaveBeenCalledWith("vb:missing", {
+      backends: [{ flavor: "vercel-kv" }],
+      parseJson: false,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload).toMatchObject({
+      ok: true,
+      key: "vb:missing",
+      hit: false,
+      flavor: null,
+      raw: null,
+      valueType: "null",
+      parsed: false,
+      parsedType: "null",
+    });
+    expect(res.jsonPayload.tried).toEqual([
+      { flavor: "vercel-kv", ok: true, hit: false, count: 0 },
+      { flavor: "upstash-redis", ok: false, hit: false, count: 0 },
+    ]);
+  });
+
+  it("parses JSON strings and reports parsed metadata", async () => {
+    const rawJson = '{"foo":"bar","arr":[1,2,3]}';
+    kvBackends.mockReturnValueOnce([{ flavor: "vercel-kv" }]);
+    readKeyFromBackends.mockResolvedValueOnce({
+      value: rawJson,
+      hit: true,
+      flavor: "vercel-kv",
+    });
+
+    const req = { method: "GET", query: { key: "vb:json" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload).toMatchObject({
+      ok: true,
+      key: "vb:json",
+      hit: true,
+      flavor: "vercel-kv",
+      raw: rawJson,
+      value: { foo: "bar", arr: [1, 2, 3] },
+      valueType: "string",
+      parsed: true,
+      parsedType: "object",
+    });
+  });
+
+  it("returns native objects without stringifying them", async () => {
+    const native = { foo: "bar", nested: { answer: 42 } };
+    kvBackends.mockReturnValueOnce([{ flavor: "vercel-kv" }]);
+    readKeyFromBackends.mockResolvedValueOnce({
+      value: native,
+      hit: true,
+      flavor: "vercel-kv",
+    });
+
+    const req = { method: "GET", query: { key: "vb:native" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.value).toEqual(native);
+    expect(res.jsonPayload.raw).toEqual(native);
+    expect(typeof res.jsonPayload.raw).toBe("object");
+    expect(res.jsonPayload).toMatchObject({
+      ok: true,
+      key: "vb:native",
+      hit: true,
+      flavor: "vercel-kv",
+      valueType: "object",
+      parsed: false,
+      parsedType: "object",
+    });
+  });
+});
+

--- a/pages/api/kv/get.js
+++ b/pages/api/kv/get.js
@@ -3,6 +3,52 @@
 
 const { kvBackends, readKeyFromBackends } = require("../../../lib/kv-helpers");
 
+function describeType(value) {
+  if (Array.isArray(value)) return "array";
+  if (value === null) return "null";
+  return typeof value;
+}
+
+function interpretRaw(raw) {
+  const normalized = raw === undefined ? null : raw;
+
+  if (typeof normalized !== "string") {
+    return {
+      value: normalized,
+      parsed: false,
+      parsedType: describeType(normalized),
+      error: null,
+    };
+  }
+
+  const trimmed = normalized.trim();
+  if (!trimmed) {
+    return {
+      value: null,
+      parsed: false,
+      parsedType: "null",
+      error: null,
+    };
+  }
+
+  try {
+    const parsedValue = JSON.parse(trimmed);
+    return {
+      value: parsedValue,
+      parsed: true,
+      parsedType: describeType(parsedValue),
+      error: null,
+    };
+  } catch {
+    return {
+      value: normalized,
+      parsed: false,
+      parsedType: null,
+      error: "invalid_json",
+    };
+  }
+}
+
 function extractKey(req) {
   if (req?.query?.key != null) {
     const raw = Array.isArray(req.query.key) ? req.query.key[0] : req.query.key;
@@ -18,16 +64,23 @@ function extractKey(req) {
 }
 
 module.exports = async function handler(req, res) {
+  if (req?.method && req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ ok: false, error: "method_not_allowed" });
+  }
+
   try {
     res.setHeader("Cache-Control", "no-store");
     const rawKey = extractKey(req);
     const key = String(rawKey || "").trim();
     if (!key) {
-      return res.status(200).json({ ok: true, key: null, hit: false, flavor: null, value: null });
+      return res.status(400).json({ ok: false, error: "missing_key" });
     }
 
     const backends = kvBackends();
-    const read = await readKeyFromBackends(key, { backends });
+    const read = await readKeyFromBackends(key, { backends, parseJson: false });
+    const rawValue = read?.value === undefined ? null : read.value;
+    const { value, parsed, parsedType, error } = interpretRaw(rawValue);
     const tried = Array.isArray(read?.tried)
       ? read.tried.map((attempt) => ({
           flavor: attempt?.flavor || "unknown",
@@ -42,13 +95,21 @@ module.exports = async function handler(req, res) {
       key,
       hit: Boolean(read?.hit),
       flavor: read?.flavor || null,
-      value: read?.value ?? null,
+      raw: rawValue,
+      value,
+      valueType: describeType(rawValue),
+      parsed,
+      parsedType,
     };
+
+    if (!parsed && error) {
+      response.parseError = error;
+    }
 
     if (tried.length) response.tried = tried;
 
     return res.status(200).json(response);
   } catch (err) {
-    return res.status(200).json({ ok: false, error: String(err?.message || err) });
+    return res.status(500).json({ ok: false, error: String(err?.message || err) });
   }
 };


### PR DESCRIPTION
## Summary
- harden the /api/kv/get handler with method/key validation and richer parsing metadata
- add a focused Jest suite for /api/kv/get that exercises KV miss and hit scenarios via mocked helpers

## Testing
- npm test -- kv-get

------
https://chatgpt.com/codex/tasks/task_e_68d699c13c18832289c555ddd1b78c1c