### PR TITLE
Add fallback for :last snapshots in apply-learning

### DIFF
--- a/pages/api/cron/apply-learning.impl.js
+++ b/pages/api/cron/apply-learning.impl.js
@@ -838,6 +838,14 @@ async function loadSnapshotsForDay(ymd, options = {}, context = {}) {
       return { items, meta: { source: key } };
     }
   }
+  const lastKey = `vb:day:${ymd}:last`;
+  {
+    const { items } = await readSnapshot(lastKey, { sourceSlot: "last" }, context);
+    if (items.length > 0) {
+      const deduped = dedupeByFixtureStrongest(items);
+      return { items: deduped, meta: { source: lastKey, slot: "last" } };
+    }
+  }
   let aggregated = [];
   const slotSizes = {};
   for (const slot of ["am", "pm", "late"]) {


### PR DESCRIPTION
## Summary
- add a vb:day:…:last fallback in the loadSnapshotsForDay helper so we dedupe and return the freshest snapshot before aggregating per-slot data
- update the apply-learning tests to share trace extraction logic and cover a :last-only scenario

## Testing
- npm test -- apply-learning

------
https://chatgpt.com/codex/tasks/task_e_68d6a18dc7908322bf86c44e4d63447a