### PR TITLE
Detect production KV misconfiguration and surface API errors

### DIFF
--- a/__tests__/lib/kv-helpers-misconfig.test.js
+++ b/__tests__/lib/kv-helpers-misconfig.test.js
@@ -1,0 +1,58 @@
+const originalEnv = process.env;
+
+describe("kvBackends production drift detection", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("throws a structured error when production lacks tokens but other envs are configured", () => {
+    process.env.VERCEL_ENV = "production";
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    delete process.env.KV_REST_API_READ_ONLY_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.KV_REST_API_URL_PREVIEW = "https://preview.example";
+    process.env.KV_REST_API_TOKEN_PREVIEW = "preview-token";
+
+    const {
+      kvBackends,
+      KvEnvMisconfigurationError,
+      PRODUCTION_MISCONFIG_CODE,
+    } = require("../../lib/kv-helpers");
+
+    let thrown = null;
+    try {
+      kvBackends();
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(KvEnvMisconfigurationError);
+    expect(thrown?.code).toBe(PRODUCTION_MISCONFIG_CODE);
+    expect(Array.isArray(thrown?.meta?.configuredElsewhere)).toBe(true);
+    expect(thrown.meta.configuredElsewhere).toEqual(
+      expect.arrayContaining(["KV_REST_API_URL_PREVIEW", "KV_REST_API_TOKEN_PREVIEW"])
+    );
+  });
+
+  it("returns an empty list without throwing when not in production", () => {
+    process.env.VERCEL_ENV = "preview";
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    delete process.env.KV_REST_API_READ_ONLY_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.KV_REST_API_URL_PREVIEW = "https://preview.example";
+    process.env.KV_REST_API_TOKEN_PREVIEW = "preview-token";
+
+    const { kvBackends } = require("../../lib/kv-helpers");
+
+    expect(kvBackends()).toEqual([]);
+  });
+});

--- a/__tests__/pages/api/kv-get.test.js
+++ b/__tests__/pages/api/kv-get.test.js
@@ -1,0 +1,69 @@
+const originalEnv = process.env;
+const realFetch = global.fetch;
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    payload: null,
+    headers: {},
+    setHeader(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.payload = data;
+      return this;
+    },
+  };
+}
+
+describe("/api/kv/get", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    global.fetch = jest.fn(() => {
+      throw new Error("fetch should not be called in this test");
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = realFetch;
+  });
+
+  it("reports production KV misconfiguration when drift is detected", async () => {
+    process.env.VERCEL_ENV = "production";
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    delete process.env.KV_REST_API_READ_ONLY_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.KV_REST_API_URL_PREVIEW = "https://preview.example";
+    process.env.KV_REST_API_TOKEN_PREVIEW = "preview-token";
+
+    const { PRODUCTION_MISCONFIG_CODE } = require("../../../lib/kv-helpers");
+    const handler = require("../../../pages/api/kv/get.js");
+
+    const req = {
+      method: "GET",
+      query: { key: "vb:day:2024-01-01:combined" },
+      headers: { host: "example.com" },
+    };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.payload).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "Confirm env vars present in Production",
+        code: PRODUCTION_MISCONFIG_CODE,
+      })
+    );
+  });
+});

--- a/lib/kv-helpers.js
+++ b/lib/kv-helpers.js
@@ -3,6 +3,50 @@
 
 const CLEARED_STRING_MARKERS = new Set(["null", "undefined", "nil", "none"]);
 
+const PRODUCTION_MISCONFIG_CODE = "kv_env_missing_production_tokens";
+
+class KvEnvMisconfigurationError extends Error {
+  constructor(meta = {}) {
+    super("Confirm env vars present in Production");
+    this.name = "KvEnvMisconfigurationError";
+    this.code = PRODUCTION_MISCONFIG_CODE;
+    this.meta = meta && typeof meta === "object" ? meta : {};
+  }
+}
+
+const ALT_ENV_SUFFIXES = [
+  "_DEVELOPMENT",
+  "_DEV",
+  "_PREVIEW",
+  "_STAGING",
+  "_STAGE",
+  "_TEST",
+  "_QA",
+  "_SANDBOX",
+  "_LAB",
+  "_LABS",
+  "_NONPROD",
+  "_NON_PROD",
+];
+
+function collectAltEnvKvConfig(env) {
+  const configured = [];
+  if (!env || typeof env !== "object") return configured;
+  for (const [key, rawValue] of Object.entries(env)) {
+    if (!rawValue) continue;
+    if (!key || typeof key !== "string") continue;
+    const upperKey = key.toUpperCase();
+    if (!upperKey.startsWith("KV_REST_API_") && !upperKey.startsWith("UPSTASH_REDIS_REST_")) {
+      continue;
+    }
+    if (!ALT_ENV_SUFFIXES.some((suffix) => upperKey.endsWith(suffix))) continue;
+    const value = typeof rawValue === "string" ? rawValue.trim() : String(rawValue || "").trim();
+    if (!value) continue;
+    configured.push(key);
+  }
+  return configured;
+}
+
 function trimKey(key) {
   return typeof key === "string" ? key.trim() : "";
 }
@@ -22,6 +66,13 @@ function kvBackends() {
   }
   if (upstashUrlRaw && upstashToken) {
     out.push({ flavor: "upstash-redis", url: sanitizeUrl(upstashUrlRaw), token: upstashToken });
+  }
+  const vercelEnv = String(process.env.VERCEL_ENV || "").toLowerCase();
+  if (out.length === 0 && vercelEnv === "production") {
+    const configuredElsewhere = collectAltEnvKvConfig(process.env);
+    if (configuredElsewhere.length > 0) {
+      throw new KvEnvMisconfigurationError({ configuredElsewhere });
+    }
   }
   return out;
 }
@@ -311,4 +362,6 @@ module.exports = {
   extractArray,
   countItems,
   looksClearedString,
+  KvEnvMisconfigurationError,
+  PRODUCTION_MISCONFIG_CODE,
 };


### PR DESCRIPTION
## Summary
- detect missing production KV/Redis credentials when alternate environment secrets exist
- bubble a structured production misconfiguration error through kv/get and cron backfill handlers
- add targeted tests covering the new misconfiguration detection and API response

## Testing
- npx jest --runInBand __tests__/lib/kv-helpers-misconfig.test.js __tests__/pages/api/kv-get.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6a18fa0c883228b580d6c90d4b55f