### PR TITLE
Centralize league tier configuration and helpers

### DIFF
--- a/config/leagues.tiers.json
+++ b/config/leagues.tiers.json
@@ -1,0 +1,41 @@
+{
+  "tiers": {
+    "T1": {
+      "ids": [39, 40, 61, 78, 135, 140, 2, 3, 848],
+      "patterns": [
+        "Premier\\s+League",
+        "La\\s+Liga",
+        "Serie\\s+A",
+        "Bundesliga",
+        "Ligue\\s+1",
+        "Champions\\s+League",
+        "UEFA\\s*Champ"
+      ],
+      "target_ratio": 0.5
+    },
+    "T2": {
+      "ids": [41, 42, 88, 94, 95, 96, 99, 103, 144, 208, 210],
+      "patterns": [
+        "Championship",
+        "Eredivisie",
+        "Primeira",
+        "Liga\\s+Portugal",
+        "Super\\s+Lig",
+        "Pro\\s+League",
+        "Bundesliga\\s+2",
+        "Serie\\s+B",
+        "LaLiga\\s+2",
+        "Ligue\\s+2",
+        "Eerste\\s+Divisie"
+      ],
+      "target_ratio": 0.35
+    }
+  },
+  "denylist_patterns": [
+    "U-?\\d{2}",
+    "youth",
+    "reserve",
+    "women",
+    "futsal"
+  ]
+}

--- a/lib/leaguesConfig.js
+++ b/lib/leaguesConfig.js
@@ -1,0 +1,255 @@
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_CONFIG = {
+  tiers: {
+    T1: {
+      ids: [39, 40, 61, 78, 135, 140, 2, 3, 848],
+      patterns: [
+        "Premier\\s+League",
+        "La\\s+Liga",
+        "Serie\\s+A",
+        "Bundesliga",
+        "Ligue\\s+1",
+        "Champions\\s+League",
+        "UEFA\\s*Champ",
+      ],
+      target_ratio: 0.5,
+    },
+    T2: {
+      ids: [41, 42, 88, 94, 95, 96, 99, 103, 144, 208, 210],
+      patterns: [
+        "Championship",
+        "Eredivisie",
+        "Primeira",
+        "Liga\\s+Portugal",
+        "Super\\s+Lig",
+        "Pro\\s+League",
+        "Bundesliga\\s+2",
+        "Serie\\s+B",
+        "LaLiga\\s+2",
+        "Ligue\\s+2",
+        "Eerste\\s+Divisie",
+      ],
+      target_ratio: 0.35,
+    },
+  },
+  denylist_patterns: ["U-?\\d{2}", "youth", "reserve", "women", "futsal"],
+};
+
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function compilePattern(pattern) {
+  if (pattern instanceof RegExp) return pattern;
+  if (typeof pattern !== "string") return null;
+  if (!pattern) return null;
+  try {
+    return new RegExp(pattern, "i");
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTier(key, rawTier = {}, fallbackTier = {}) {
+  const idsSource = Array.isArray(rawTier.ids) ? rawTier.ids : fallbackTier.ids || [];
+  const ids = idsSource
+    .map((id) => toFiniteNumber(id))
+    .filter((id) => id != null);
+
+  const patternSource = Array.isArray(rawTier.patterns)
+    ? rawTier.patterns
+    : fallbackTier.patterns || [];
+  const regexes = patternSource
+    .map((p) => compilePattern(p))
+    .filter(Boolean);
+
+  const rawTarget = rawTier.target_ratio ?? fallbackTier.target_ratio;
+  const targetRatio = toFiniteNumber(rawTarget);
+
+  return {
+    key,
+    ids,
+    idSet: new Set(ids),
+    patterns: patternSource,
+    regexes,
+    targetRatio: Number.isFinite(targetRatio) ? targetRatio : null,
+  };
+}
+
+function normalizeDenylist(rawList, fallbackList = []) {
+  const src = Array.isArray(rawList) ? rawList : fallbackList;
+  const patterns = src.filter((p) => typeof p === "string" && p);
+  const regexes = patterns.map((p) => compilePattern(p)).filter(Boolean);
+  return { patterns, regexes };
+}
+
+function normalizeConfig(raw = {}) {
+  const tiers = {};
+  const rawTiers = raw && typeof raw === "object" ? raw.tiers || {} : {};
+  const fallbackTiers = DEFAULT_CONFIG.tiers;
+  for (const key of Object.keys(fallbackTiers)) {
+    tiers[key] = normalizeTier(key, rawTiers[key] || {}, fallbackTiers[key] || {});
+  }
+  const denylist = normalizeDenylist(raw.denylist_patterns, DEFAULT_CONFIG.denylist_patterns);
+  return { tiers, denylist };
+}
+
+const DEFAULT_NORMALIZED = normalizeConfig(DEFAULT_CONFIG);
+
+let cachedConfig = null;
+let cachedMtime = null;
+let cachedPath = null;
+
+function configPath() {
+  return path.join(process.cwd(), "config", "leagues.tiers.json");
+}
+
+function loadConfigFromDisk(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    return normalizeConfig(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function getLeaguesConfig() {
+  const filePath = configPath();
+  try {
+    const stats = fs.statSync(filePath);
+    if (!cachedConfig || cachedPath !== filePath || cachedMtime !== stats.mtimeMs) {
+      const loaded = loadConfigFromDisk(filePath) || DEFAULT_NORMALIZED;
+      cachedConfig = loaded;
+      cachedMtime = stats.mtimeMs;
+      cachedPath = filePath;
+    }
+  } catch {
+    if (!cachedConfig) {
+      cachedConfig = DEFAULT_NORMALIZED;
+      cachedPath = filePath;
+      cachedMtime = null;
+    }
+  }
+  return cachedConfig || DEFAULT_NORMALIZED;
+}
+
+function extractLeagueMeta(league) {
+  if (league == null) return { id: null, name: "" };
+
+  if (typeof league === "number") {
+    return Number.isFinite(league) ? { id: league, name: "" } : { id: null, name: "" };
+  }
+
+  if (typeof league === "string") {
+    const trimmed = league.trim();
+    if (!trimmed) return { id: null, name: "" };
+    const asNumber = toFiniteNumber(trimmed);
+    if (asNumber != null) return { id: asNumber, name: trimmed };
+    return { id: null, name: trimmed };
+  }
+
+  if (typeof league === "object") {
+    if (league.league && typeof league.league === "object") {
+      return extractLeagueMeta(league.league);
+    }
+    const idCandidates = [league.id, league.league_id, league.leagueId];
+    let id = null;
+    for (const cand of idCandidates) {
+      const num = toFiniteNumber(cand);
+      if (num != null) {
+        id = num;
+        break;
+      }
+    }
+    const nameCandidates = [
+      league.name,
+      league.league_name,
+      league.leagueName,
+      league.competition,
+      league.tournament,
+      league.display,
+    ];
+    let name = "";
+    for (const cand of nameCandidates) {
+      if (typeof cand === "string") {
+        const trimmed = cand.trim();
+        if (trimmed) {
+          name = trimmed;
+          break;
+        }
+      }
+    }
+    return { id, name };
+  }
+
+  return { id: null, name: "" };
+}
+
+function pickRegexes(config, tierKey, override) {
+  if (override) {
+    const arr = Array.isArray(override) ? override : [override];
+    return arr
+      .map((item) => {
+        if (item instanceof RegExp) return item;
+        if (typeof item === "string") return compilePattern(item);
+        return null;
+      })
+      .filter(Boolean);
+  }
+  return config.tiers[tierKey]?.regexes || [];
+}
+
+function matchLeagueTier(league, options = {}) {
+  const config = getLeaguesConfig();
+  const { id, name } = extractLeagueMeta(league);
+
+  if (id != null) {
+    for (const key of Object.keys(config.tiers)) {
+      if (config.tiers[key]?.idSet?.has(id)) {
+        return key;
+      }
+    }
+  }
+
+  if (name) {
+    const { regexOverrides = {} } = options;
+    for (const key of Object.keys(config.tiers)) {
+      const regexes = pickRegexes(config, key, regexOverrides[key]);
+      if (regexes.some((re) => re.test(name))) {
+        return key;
+      }
+    }
+  }
+
+  return null;
+}
+
+function resolveLeagueTierKey(league, options = {}) {
+  const matched = matchLeagueTier(league, options);
+  return matched || "T3";
+}
+
+function getLeagueTargetRatio(tierKey) {
+  const config = getLeaguesConfig();
+  const tier = config.tiers[tierKey];
+  return typeof tier?.targetRatio === "number" ? tier.targetRatio : null;
+}
+
+function isLeagueDenied(league) {
+  const config = getLeaguesConfig();
+  const { name } = extractLeagueMeta(league);
+  if (!name) return false;
+  return config.denylist.regexes.some((re) => re.test(name));
+}
+
+module.exports = {
+  getLeaguesConfig,
+  matchLeagueTier,
+  resolveLeagueTierKey,
+  getLeagueTargetRatio,
+  isLeagueDenied,
+};

--- a/lib/learning/runtime.js
+++ b/lib/learning/runtime.js
@@ -1,3 +1,5 @@
+const { matchLeagueTier } = require("../leaguesConfig");
+
 const clamp = (value, lo, hi) => {
   if (!Number.isFinite(value)) return lo;
   return Math.max(lo, Math.min(hi, value));
@@ -57,12 +59,6 @@ function safeRegex(src, fallback) {
   }
 }
 
-const DEFAULT_TIER1_RE = /(Premier\s+League|La\s+Liga|Serie\s+A|Bundesliga|Ligue\s+1|Champions\s+League|UEFA\s*Champ)/i;
-const DEFAULT_TIER2_RE = /(Championship|Eredivisie|Primeira|Liga\s+Portugal|Super\s+Lig|Pro\s+League|Bundesliga\s+2|Serie\s+B|LaLiga\s+2|Ligue\s+2|Eerste\s+Divisie)/i;
-
-const TIER1_IDS = new Set([39, 40, 61, 78, 135, 140, 2, 3, 848, 848]);
-const TIER2_IDS = new Set([41, 42, 88, 94, 95, 96, 99, 103, 144, 208, 210]);
-
 function resolveLeagueTier(league, env = {}) {
   if (!league || typeof league !== "object") return "T3";
 
@@ -75,21 +71,14 @@ function resolveLeagueTier(league, env = {}) {
     return "T3";
   }
 
-  const id = toFiniteNumber(league.id || league.league_id || league.leagueId);
-  if (id != null) {
-    if (TIER1_IDS.has(id)) return "T1";
-    if (TIER2_IDS.has(id)) return "T2";
-  }
+  const overrides = {};
+  const envTier1 = safeRegex(env.TIER1_RE ?? process.env?.TIER1_RE, null);
+  const envTier2 = safeRegex(env.TIER2_RE ?? process.env?.TIER2_RE, null);
+  if (envTier1) overrides.T1 = [envTier1];
+  if (envTier2) overrides.T2 = [envTier2];
 
-  const name = String(league.name || league.league_name || "").trim();
-  if (name) {
-    const tier1Re = safeRegex(env.TIER1_RE, DEFAULT_TIER1_RE);
-    const tier2Re = safeRegex(env.TIER2_RE, DEFAULT_TIER2_RE);
-    if (tier1Re.test(name)) return "T1";
-    if (tier2Re.test(name)) return "T2";
-  }
-
-  return "T3";
+  const matched = matchLeagueTier(league, { regexOverrides: overrides });
+  return matched || "T3";
 }
 
 function resolveMarketBucket(rawMarket) {

--- a/pages/api/cron/rebuild.js
+++ b/pages/api/cron/rebuild.js
@@ -65,10 +65,10 @@ const {
   afxCacheSet,
 } = require("../../../lib/sources/apiFootball");
 const { saveCombinedAlias } = require("../../../lib/kv-helpers");
+const { isLeagueDenied } = require("../../../lib/leaguesConfig");
 
 /* ---------- utils ---------- */
 function canonicalSlot(x){ x=String(x||"auto").toLowerCase(); return x==="late"||x==="am"||x==="pm"?x:"auto"; }
-function isYouthLeague(name=""){ name=String(name||"").toLowerCase(); return /(u-?\d{2}|youth|reserve|women|futsal)/.test(name); }
 function kickoffISOFromAF(fix){ return fix?.fixture?.date || null; }
 function leagueFromAF(fix){ return { id: fix?.league?.id, name: fix?.league?.name, country: fix?.league?.country, season: fix?.league?.season }; }
 function teamsFromAF(fix){ return { home: fix?.teams?.home?.name, away: fix?.teams?.away?.name, home_id: fix?.teams?.home?.id, away_id: fix?.teams?.away?.id }; }
@@ -1143,7 +1143,7 @@ export default async function handler(req, res){
         return respond({ items: preserved, source: "budget" });
       }
       const mapped = list
-        .filter(f => !isYouthLeague(f?.league?.name))
+        .filter(f => !isLeagueDenied(f?.league))
         .filter(f => slotFilter(kickoffISOFromAF(f), slot))
         .map(f => {
           const dateISO = kickoffISOFromAF(f);


### PR DESCRIPTION
## Summary
- add a shared JSON configuration for tiered leagues and denial patterns
- implement a cached loader that exposes tier resolution and denylist helpers
- update runtime utilities and API routes to consume the shared helpers instead of inline regexes

## Testing
- `npm test -- --runTestsByPath __tests__/lib/learning-runtime.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d6be08b1c88322867d249841e471f9