### PR TITLE
Adjust league configuration ratios and denylist handling

### DIFF
--- a/config/leagues.tiers.json
+++ b/config/leagues.tiers.json
@@ -11,7 +11,7 @@
         "Champions\\s+League",
         "UEFA\\s*Champ"
       ],
-      "target_ratio": 0.5
+      "target_ratio": 0.7
     },
     "T2": {
       "ids": [41, 42, 88, 94, 95, 96, 99, 103, 144, 208, 210],
@@ -28,14 +28,21 @@
         "Ligue\\s+2",
         "Eerste\\s+Divisie"
       ],
-      "target_ratio": 0.35
+      "target_ratio": 0.2
+    },
+    "T3": {
+      "ids": [],
+      "patterns": [],
+      "target_ratio": 0.1
     }
   },
   "denylist_patterns": [
     "U-?\\d{2}",
     "youth",
-    "reserve",
+    "reserves?",
     "women",
+    "amateur",
+    "friendlies?\\s*B",
     "futsal"
   ]
 }

--- a/lib/leaguesConfig.js
+++ b/lib/leaguesConfig.js
@@ -14,7 +14,7 @@ const DEFAULT_CONFIG = {
         "Champions\\s+League",
         "UEFA\\s*Champ",
       ],
-      target_ratio: 0.5,
+      target_ratio: 0.7,
     },
     T2: {
       ids: [41, 42, 88, 94, 95, 96, 99, 103, 144, 208, 210],
@@ -31,10 +31,23 @@ const DEFAULT_CONFIG = {
         "Ligue\\s+2",
         "Eerste\\s+Divisie",
       ],
-      target_ratio: 0.35,
+      target_ratio: 0.2,
+    },
+    T3: {
+      ids: [],
+      patterns: [],
+      target_ratio: 0.1,
     },
   },
-  denylist_patterns: ["U-?\\d{2}", "youth", "reserve", "women", "futsal"],
+  denylist_patterns: [
+    "U-?\\d{2}",
+    "youth",
+    "reserves?",
+    "women",
+    "amateur",
+    "friendlies?\\s*B",
+    "futsal",
+  ],
 };
 
 function toFiniteNumber(value) {
@@ -66,7 +79,11 @@ function normalizeTier(key, rawTier = {}, fallbackTier = {}) {
     .map((p) => compilePattern(p))
     .filter(Boolean);
 
-  const rawTarget = rawTier.target_ratio ?? fallbackTier.target_ratio;
+  const rawTarget =
+    rawTier.target_ratio ??
+    rawTier.targetRatio ??
+    fallbackTier.target_ratio ??
+    fallbackTier.targetRatio;
   const targetRatio = toFiniteNumber(rawTarget);
 
   return {
@@ -90,7 +107,11 @@ function normalizeConfig(raw = {}) {
   const tiers = {};
   const rawTiers = raw && typeof raw === "object" ? raw.tiers || {} : {};
   const fallbackTiers = DEFAULT_CONFIG.tiers;
-  for (const key of Object.keys(fallbackTiers)) {
+  const tierKeys = new Set([
+    ...Object.keys(fallbackTiers),
+    ...Object.keys(rawTiers || {}),
+  ]);
+  for (const key of tierKeys) {
     tiers[key] = normalizeTier(key, rawTiers[key] || {}, fallbackTiers[key] || {});
   }
   const denylist = normalizeDenylist(raw.denylist_patterns, DEFAULT_CONFIG.denylist_patterns);


### PR DESCRIPTION
## Summary
- update league tier config ratios to reflect the latest business mix and add an explicit Tier 3 entry
- expand the league denylist patterns to cover additional amateur and reserve competitions
- teach the leagues config loader to normalize both snake and camel case ratio keys while supporting custom tiers

## Testing
- npm test -- lib/leaguesConfig *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c3c40ad08322b9b4d5feb49dfa01