### PR TITLE
Add tier-aware allocation to match selector

### DIFF
--- a/lib/matchSelector.js
+++ b/lib/matchSelector.js
@@ -9,6 +9,11 @@ const BASE_BACKOFF_MS = 500;
 const LAST_GOOD_TTL_MS = 10 * 60 * 1000; // 10 minuta
 
 const { afxTeamStats } = require('./sources/apiFootball');
+const {
+  resolveLeagueTierKey,
+  isLeagueDenied,
+  getLeagueTargetRatio,
+} = require('./leaguesConfig');
 
 const FALLBACK_BASE_PROBS = { home: 0.45, draw: 0.25, away: 0.3 };
 const FALLBACK_BTTS_PROBABILITY = 0.4;
@@ -20,6 +25,7 @@ const DEFAULT_HOME_WIN_RATE = 0.45;
 const DEFAULT_AWAY_WIN_RATE = 0.3;
 const DEFAULT_DRAW_RATE = 0.25;
 const DEFAULT_POINTS_PER_MATCH = 1.35;
+const MAX_SELECTIONS = 10;
 
 // In-memory last good cache (any source)
 let lastGood = {
@@ -466,6 +472,126 @@ function compactObject(obj) {
   );
 }
 
+function normalizeTierKey(tier) {
+  if (tier === 'T1' || tier === 'T2') return tier;
+  return 'T3';
+}
+
+function candidateRankScore(candidate) {
+  const score = toNumber(candidate?.rankScore);
+  if (Number.isFinite(score)) return score;
+  const confidence = toNumber(candidate?.confidence);
+  return Number.isFinite(confidence) ? confidence : 0;
+}
+
+function allocateByTier(candidates, maxCount = MAX_SELECTIONS) {
+  const normalized = candidates.map((candidate) => ({
+    ...candidate,
+    tier: normalizeTierKey(candidate.tier),
+  }));
+
+  const groups = { T1: [], T2: [], T3: [] };
+  for (const candidate of normalized) {
+    groups[candidate.tier].push(candidate);
+  }
+
+  const availableCounts = {
+    T1: groups.T1.length,
+    T2: groups.T2.length,
+    T3: groups.T3.length,
+  };
+
+  const t1TargetRatioRaw = getLeagueTargetRatio('T1');
+  const t1TargetRatio = Math.max(
+    0.7,
+    Number.isFinite(t1TargetRatioRaw) ? t1TargetRatioRaw : 0
+  );
+  const targetT1Count = Math.min(maxCount, Math.ceil(maxCount * t1TargetRatio));
+
+  const sortedGroups = {
+    T1: groups.T1.sort((a, b) => candidateRankScore(b) - candidateRankScore(a)),
+    T2: groups.T2.sort((a, b) => candidateRankScore(b) - candidateRankScore(a)),
+    T3: groups.T3.sort((a, b) => candidateRankScore(b) - candidateRankScore(a)),
+  };
+
+  const picks = [];
+  const pickedCounts = { T1: 0, T2: 0, T3: 0 };
+
+  const fillFromGroup = (key) => {
+    const group = sortedGroups[key];
+    for (const candidate of group) {
+      if (picks.length >= maxCount) break;
+      picks.push(candidate);
+      pickedCounts[key] += 1;
+    }
+  };
+
+  fillFromGroup('T1');
+  fillFromGroup('T2');
+  fillFromGroup('T3');
+
+  const shortfall = {
+    T1: Math.max(0, targetT1Count - pickedCounts.T1),
+  };
+
+  return {
+    picks,
+    metrics: {
+      maxCount,
+      totalCandidates: normalized.length,
+      availableCounts,
+      pickedCounts,
+      target: {
+        tier: 'T1',
+        ratio: t1TargetRatio,
+        required: targetT1Count,
+      },
+      shortfall,
+      unfilledSlots: Math.max(0, maxCount - picks.length),
+      backfillOrder: ['T1', 'T2', 'T3'],
+      metTarget: shortfall.T1 === 0,
+    },
+  };
+}
+
+async function buildTieredSelections(fixtures, mapper) {
+  const candidates = [];
+  let deniedCount = 0;
+
+  for (const fixture of fixtures) {
+    const selection = await mapper(fixture);
+    if (!selection) continue;
+
+    const leagueMeta = selection.league || fixture.league || null;
+    if (isLeagueDenied(leagueMeta)) {
+      deniedCount += 1;
+      continue;
+    }
+
+    const tier = resolveLeagueTierKey(leagueMeta);
+    const candidate = {
+      ...selection,
+      tier,
+    };
+
+    if (candidate.rankScore === undefined || candidate.rankScore === null) {
+      const score = candidateRankScore(candidate);
+      candidate.rankScore = score;
+    }
+
+    candidates.push(candidate);
+  }
+
+  const allocation = allocateByTier(candidates, MAX_SELECTIONS);
+  return {
+    picks: allocation.picks,
+    allocation: {
+      ...allocation.metrics,
+      deniedCount,
+    },
+  };
+}
+
 async function computeModelProbs(fixture, metaOverride) {
   const meta = metaOverride || extractFixtureMeta(fixture);
   const missing = [];
@@ -626,47 +752,46 @@ async function trySportMonks(dateStr) {
   )}&tz=UTC`;
   const result = await fetchWithRetry(url);
   if (result.ok && Array.isArray(result.data?.data)) {
-    const fixtures = (result.data.data || []).slice(0, 10);
-    const picks = await Promise.all(
-      fixtures.map(async (f) => {
-        const simple = await deriveSimpleModel(f);
-        return {
-          fixture_id: f.id,
-          league: {
-            id: f.league?.data?.id,
-            name: f.league?.data?.name,
+    const fixtures = (result.data.data || []).slice(0, MAX_SELECTIONS * 2);
+    const tiered = await buildTieredSelections(fixtures, async (f) => {
+      const simple = await deriveSimpleModel(f);
+      return {
+        fixture_id: f.id,
+        league: {
+          id: f.league?.data?.id,
+          name: f.league?.data?.name,
+        },
+        teams: {
+          home: {
+            id: f.localTeam?.data?.id,
+            name: f.localTeam?.data?.name,
           },
-          teams: {
-            home: {
-              id: f.localTeam?.data?.id,
-              name: f.localTeam?.data?.name,
-            },
-            away: {
-              id: f.visitorTeam?.data?.id,
-              name: f.visitorTeam?.data?.name,
-            },
+          away: {
+            id: f.visitorTeam?.data?.id,
+            name: f.visitorTeam?.data?.name,
           },
-          venue: { name: null },
-          datetime_local: f.time || null,
-          model_probs: simple.model_probs,
-          predicted: simple.predicted,
-          confidence: simple.confidence,
-          rankScore: simple.confidence,
-          btts_probability: simple.btts_probability,
-          over25_probability: simple.over25_probability,
-        };
-      })
-    );
+        },
+        venue: { name: null },
+        datetime_local: f.time || null,
+        model_probs: simple.model_probs,
+        predicted: simple.predicted,
+        confidence: simple.confidence,
+        rankScore: simple.confidence,
+        btts_probability: simple.btts_probability,
+        over25_probability: simple.over25_probability,
+      };
+    });
 
     return {
-      picks,
+      picks: tiered.picks,
       debug: {
         source: 'sportmonks',
         date: dateStr,
-        total_fetched: picks.length,
+        total_fetched: tiered.picks.length,
         raw_source: result.data,
         request_url: url,
         status: result.status,
+        allocation: tiered.allocation,
       },
     };
   } else {
@@ -697,50 +822,49 @@ async function tryAPIFootball(dateStr) {
     const res = await fetch(url, { headers });
     const json = await res.json();
     if (res.ok && Array.isArray(json.response)) {
-      const fixtures = json.response.slice(0, 10);
-      const picks = await Promise.all(
-        fixtures.map(async (f) => {
-          const simple = await deriveSimpleModel(f);
-          return {
-            fixture_id: f.fixture?.id ?? null,
-            league: {
-              id: f.league?.id ?? null,
-              name: f.league?.name ?? null,
+      const fixtures = json.response.slice(0, MAX_SELECTIONS * 2);
+      const tiered = await buildTieredSelections(fixtures, async (f) => {
+        const simple = await deriveSimpleModel(f);
+        return {
+          fixture_id: f.fixture?.id ?? null,
+          league: {
+            id: f.league?.id ?? null,
+            name: f.league?.name ?? null,
+          },
+          teams: {
+            home: {
+              id: f.teams?.home?.id ?? null,
+              name: f.teams?.home?.name ?? null,
             },
-            teams: {
-              home: {
-                id: f.teams?.home?.id ?? null,
-                name: f.teams?.home?.name ?? null,
-              },
-              away: {
-                id: f.teams?.away?.id ?? null,
-                name: f.teams?.away?.name ?? null,
-              },
+            away: {
+              id: f.teams?.away?.id ?? null,
+              name: f.teams?.away?.name ?? null,
             },
-            venue: { name: f.fixture?.venue?.name || null },
-            datetime_local: {
-              date_time: f.fixture?.date,
-              timestamp: f.fixture?.timestamp,
-              timezone: f.fixture?.timezone,
-            },
-            model_probs: simple.model_probs,
-            predicted: simple.predicted,
-            confidence: simple.confidence,
-            rankScore: simple.confidence,
-            btts_probability: simple.btts_probability,
-            over25_probability: simple.over25_probability,
-          };
-        })
-      );
+          },
+          venue: { name: f.fixture?.venue?.name || null },
+          datetime_local: {
+            date_time: f.fixture?.date,
+            timestamp: f.fixture?.timestamp,
+            timezone: f.fixture?.timezone,
+          },
+          model_probs: simple.model_probs,
+          predicted: simple.predicted,
+          confidence: simple.confidence,
+          rankScore: simple.confidence,
+          btts_probability: simple.btts_probability,
+          over25_probability: simple.over25_probability,
+        };
+      });
       return {
-        picks,
+        picks: tiered.picks,
         debug: {
           source: 'api-football',
           date: dateStr,
-          total_fetched: picks.length,
+          total_fetched: tiered.picks.length,
           raw_source: json,
           request_url: url,
           status: res.status,
+          allocation: tiered.allocation,
         },
       };
     }
@@ -772,48 +896,47 @@ async function tryFootballData(dateStr) {
     const res = await fetch(url, { headers });
     const json = await res.json();
     if (res.ok && Array.isArray(json.matches)) {
-      const fixtures = json.matches.slice(0, 10);
-      const picks = await Promise.all(
-        fixtures.map(async (f) => {
-          const simple = await deriveSimpleModel(f);
-          return {
-            fixture_id: f.id,
-            league: {
-              id: f.competition?.id ?? null,
-              name: f.competition?.name ?? null,
+      const fixtures = json.matches.slice(0, MAX_SELECTIONS * 2);
+      const tiered = await buildTieredSelections(fixtures, async (f) => {
+        const simple = await deriveSimpleModel(f);
+        return {
+          fixture_id: f.id,
+          league: {
+            id: f.competition?.id ?? null,
+            name: f.competition?.name ?? null,
+          },
+          teams: {
+            home: {
+              id: f.homeTeam?.id ?? null,
+              name: f.homeTeam?.name ?? null,
             },
-            teams: {
-              home: {
-                id: f.homeTeam?.id ?? null,
-                name: f.homeTeam?.name ?? null,
-              },
-              away: {
-                id: f.awayTeam?.id ?? null,
-                name: f.awayTeam?.name ?? null,
-              },
+            away: {
+              id: f.awayTeam?.id ?? null,
+              name: f.awayTeam?.name ?? null,
             },
-            venue: { name: null },
-            datetime_local: {
-              date_time: f.utcDate,
-            },
-            model_probs: simple.model_probs,
-            predicted: simple.predicted,
-            confidence: simple.confidence,
-            rankScore: simple.confidence,
-            btts_probability: simple.btts_probability,
-            over25_probability: simple.over25_probability,
-          };
-        })
-      );
+          },
+          venue: { name: null },
+          datetime_local: {
+            date_time: f.utcDate,
+          },
+          model_probs: simple.model_probs,
+          predicted: simple.predicted,
+          confidence: simple.confidence,
+          rankScore: simple.confidence,
+          btts_probability: simple.btts_probability,
+          over25_probability: simple.over25_probability,
+        };
+      });
       return {
-        picks,
+        picks: tiered.picks,
         debug: {
           source: 'football-data',
           date: dateStr,
-          total_fetched: picks.length,
+          total_fetched: tiered.picks.length,
           raw_source: json,
           request_url: url,
           status: res.status,
+          allocation: tiered.allocation,
         },
       };
     }


### PR DESCRIPTION
## Summary
- integrate league tier helpers when building source picks and drop denied leagues
- attach league tier metadata to each selection and prioritize Tier 1 picks with backfill allocation metrics
- surface allocation counters in source debug payloads while keeping the existing fallback flow intact

## Testing
- npm test *(fails: ReferenceError: main is not defined in __tests__/pages/api/history-backend-fallback.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c3c2b20083229943e67fec92e78f