### PR TITLE
Ensure apply-learning writes canonical snapshot to KV

### DIFF
--- a/__tests__/pages/api/apply-learning.test.js
+++ b/__tests__/pages/api/apply-learning.test.js
@@ -215,6 +215,11 @@ describe("apply-learning history writer", () => {
     const histDayPayload = JSON.parse(histDayCall.body?.value);
     expect(Array.isArray(histDayPayload)).toBe(true);
     expect(histDayPayload).toEqual(parsedHist);
+    const canonicalCall = setCalls.find((call) => call.key === `vb:day:${ymd}:last`);
+    expect(canonicalCall).toBeDefined();
+    const canonicalPayload = JSON.parse(canonicalCall.body?.value);
+    expect(Array.isArray(canonicalPayload)).toBe(true);
+    expect(canonicalPayload).toEqual(parsedHist);
     expect(fetchMock).toHaveBeenCalled();
     expect(responseTrace).toEqual(
       expect.arrayContaining([
@@ -224,6 +229,11 @@ describe("apply-learning history writer", () => {
     expect(responseTrace).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ kv: "set", key: `hist:day:${ymd}`, size: parsedHist.length, ok: true }),
+      ])
+    );
+    expect(responseTrace).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kv: "set", key: `vb:day:${ymd}:last`, size: parsedHist.length, ok: true }),
       ])
     );
   });
@@ -327,6 +337,11 @@ describe("apply-learning history writer", () => {
     const parsedDay = JSON.parse(histDayCall.body?.value);
     expect(Array.isArray(parsedDay)).toBe(true);
     expect(parsedDay).toEqual(parsedHist);
+    const canonicalCall = setCalls.find((call) => call.key === `vb:day:${assumedYmd}:last`);
+    expect(canonicalCall).toBeDefined();
+    const canonicalPayload = JSON.parse(canonicalCall.body?.value);
+    expect(Array.isArray(canonicalPayload)).toBe(true);
+    expect(canonicalPayload).toEqual(parsedHist);
   });
 
   it("falls back to :last snapshot when only last is populated", async () => {
@@ -443,6 +458,11 @@ describe("apply-learning history writer", () => {
     const parsedDay = JSON.parse(histDayCall.body?.value);
     expect(Array.isArray(parsedDay)).toBe(true);
     expect(parsedDay).toEqual(parsedHist);
+    const canonicalCall = setCalls.find((call) => call.key === `vb:day:${lastYmd}:last`);
+    expect(canonicalCall).toBeDefined();
+    const canonicalPayload = JSON.parse(canonicalCall.body?.value);
+    expect(Array.isArray(canonicalPayload)).toBe(true);
+    expect(canonicalPayload).toEqual(parsedHist);
 
     const calledUrls = fetchMock.mock.calls.map(([calledUrl]) =>
       typeof calledUrl === "string" ? decodeURIComponent(calledUrl) : calledUrl

--- a/pages/api/cron/apply-learning.impl.js
+++ b/pages/api/cron/apply-learning.impl.js
@@ -904,6 +904,7 @@ async function persistHistory(ymd, history, trace, kvFlavors, options = {}) {
   const size = payload.length;
   const listKey = `hist:${ymd}`;
   const dayKey = `hist:day:${ymd}`;
+  const canonicalKey = `vb:day:${ymd}:last`;
   const meta = { ymd };
   if (slot) meta.slot = slot;
   const traceLog = trace && typeof trace.push === "function" ? trace : null;
@@ -913,6 +914,7 @@ async function persistHistory(ymd, history, trace, kvFlavors, options = {}) {
     if (traceLog) {
       traceLog.push({ kv: "set", key: listKey, size, ok: false, skipped: "no_backends", ...meta });
       traceLog.push({ kv: "set", key: dayKey, size, ok: false, skipped: "no_backends", ...meta });
+      traceLog.push({ kv: "set", key: canonicalKey, size, ok: false, skipped: "no_backends", ...meta });
     }
     return;
   }
@@ -920,9 +922,11 @@ async function persistHistory(ymd, history, trace, kvFlavors, options = {}) {
   const kv = kvClient || createKvClient(kvFlavors);
   const listMeta = { ...meta, scope: "list" };
   const dayMeta = { ...meta, scope: "day" };
+  const canonicalMeta = { ...meta, scope: "canonical" };
 
   await setJsonWithTrace(kv, listKey, payload, size, traceLog || trace, listMeta);
   await setJsonWithTrace(kv, dayKey, payload, size, traceLog || trace, dayMeta);
+  await setJsonWithTrace(kv, canonicalKey, payload, size, traceLog || trace, canonicalMeta);
 }
 
 async function setJsonWithTrace(kv, key, value, size, trace, meta = {}) {


### PR DESCRIPTION
## Summary
- ensure persistHistory stores the canonical vb:day:<ymd>:last snapshot alongside existing history keys
- extend tracing to capture the canonical write outcome for diagnostics
- update apply-learning tests to assert the canonical snapshot is saved with the expected payload

## Testing
- npm test -- --runTestsByPath __tests__/pages/api/apply-learning.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d791efd0c08322a91215caf47be067